### PR TITLE
Fix content pane showing notes outside filtered results

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -257,6 +257,46 @@ test.describe("Filtering Behavior", () => {
     expect(filteredCount).toBe(1);
     expect(filteredCount).toBeLessThan(initialCount);
   });
+
+  test("content pane shows only notes from filtered results, not notes outside the list", async ({ page }) => {
+    // First note (pinned) is "Welcome to notedude #intro"
+    const items = page.getByTestId("list-pane").getByTestId("note-item");
+    await expect(items.first()).toHaveAttribute("data-selected", "true");
+    await expect(page.getByTestId("content-pane")).toContainText("Welcome to notedude");
+
+    // Filter by #guide — note 1 does NOT have #guide, so it should be filtered out
+    await page.keyboard.press("/");
+    const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
+    await searchInput.fill("#guide");
+    await page.keyboard.press("Enter");
+
+    // The selected note should now be one of the filtered results, not note 1
+    const contentPane = page.getByTestId("content-pane");
+    await expect(contentPane).not.toContainText("Welcome to notedude");
+    await expect(items.first()).toHaveAttribute("data-selected", "true");
+    await expect(contentPane).toContainText("#guide");
+  });
+
+  test("archiving a note while filtered selects next note from filtered list", async ({ page }) => {
+    // Filter by #guide — shows notes with #guide
+    await page.keyboard.press("/");
+    const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
+    await searchInput.fill("#guide");
+    await page.keyboard.press("Enter");
+
+    const items = page.getByTestId("list-pane").getByTestId("note-item");
+    const countBefore = await items.count();
+    expect(countBefore).toBeGreaterThanOrEqual(2);
+
+    // Archive the first filtered note
+    await page.keyboard.press("Shift+Y");
+    await expect(items).toHaveCount(countBefore - 1);
+
+    // The next selected note should still be in the filtered results
+    const contentPane = page.getByTestId("content-pane");
+    await expect(contentPane).toContainText("#guide");
+    await expect(items.first()).toHaveAttribute("data-selected", "true");
+  });
 });
 
 test.describe("Pinning Behavior", () => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -393,6 +393,13 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
     }
   }, [synced, selectedId, notes]);
 
+  // Keep selectedId in sync with displayed list
+  useEffect(() => {
+    if (displayed.length > 0 && !displayed.some((n) => n.id === selectedId)) {
+      setSelectedId(displayed[0].id);
+    }
+  }, [displayed, selectedId]);
+
   // Auto-focus app on mount
   useEffect(() => {
     appRef.current?.focus();
@@ -550,9 +557,8 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
         if (e.key === "Y") {
           e.preventDefault();
           if (selectedId) {
-            const sorted = sortNotes(notes);
-            const idx = sorted.findIndex((n) => n.id === selectedId);
-            const next = sorted[idx + 1] ?? sorted[idx - 1] ?? null;
+            const idx = displayed.findIndex((n) => n.id === selectedId);
+            const next = displayed[idx + 1] ?? displayed[idx - 1] ?? null;
             const noteToArchive = notes.find((n) => n.id === selectedId);
             if (uid && !demo && noteToArchive) archiveNote(uid, selectedId, noteToArchive.content);
             setNotes((prev) => prev.filter((n) => n.id !== selectedId));


### PR DESCRIPTION
## Summary

- When a filter was active and the selected note got filtered out (by applying a new filter or archiving), the content pane still showed that note's content — a "ghost" note not visible in the list
- Added a `useEffect` that auto-selects the first displayed note when the current selection falls outside the filtered list
- Fixed the archive (Shift+Y) handler to pick the next note from the filtered `displayed` list instead of from all notes

## Test plan

- [ ] Apply a tag filter that excludes the currently selected note — content pane should switch to the first matching note
- [ ] While a filter is active, archive the selected note with Shift+Y — next selected note should be from the filtered list, not a note outside it
- [ ] Verify no regressions in normal (unfiltered) note selection and navigation

Closes #50

https://claude.ai/code/session_01Q4QJTsSNvg9jCdSoxBBgnu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4QJTsSNvg9jCdSoxBBgnu)_