### PR TITLE
Separate pin and tag-pin into independent modes with Shift+P

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -993,65 +993,112 @@ test.describe("Pin Toggle", () => {
     await expect(selected).toHaveAttribute("data-pinned", "false");
   });
 
-  test("'p' does not toggle pin in search state", async ({ page }) => {
+  test("'p' toggles pin in search state", async ({ page }) => {
     await page.keyboard.press("j");
     const selected = page.getByTestId("list-pane").locator("[data-selected='true']");
     await expect(selected).toHaveAttribute("data-pinned", "false");
     await page.keyboard.press("/");
+    await page.keyboard.press("Escape"); // enter search then back to idle
+    await page.keyboard.press("/");
+    // while in search state, press p
     await page.keyboard.press("p");
     await page.keyboard.press("Escape");
+    await expect(selected).toHaveAttribute("data-pinned", "true");
+  });
+});
+
+test.describe("Tag-Pin Toggle (Shift+P)", () => {
+  test("Shift+P tag-pins the selected note", async ({ page }) => {
+    await page.keyboard.press("j");
+    const selected = page.getByTestId("list-pane").locator("[data-selected='true']");
+    await expect(selected).toHaveAttribute("data-tagpinned", "false");
+    await page.keyboard.press("Shift+P"); // Shift+P
+    await expect(selected).toHaveAttribute("data-tagpinned", "true");
+  });
+
+  test("Shift+P again removes tag-pin", async ({ page }) => {
+    await page.keyboard.press("j");
+    const selected = page.getByTestId("list-pane").locator("[data-selected='true']");
+    await page.keyboard.press("Shift+P");
+    await expect(selected).toHaveAttribute("data-tagpinned", "true");
+    await page.keyboard.press("Shift+P");
+    await expect(selected).toHaveAttribute("data-tagpinned", "false");
+  });
+
+  test("Shift+P works in search state", async ({ page }) => {
+    await page.keyboard.press("j");
+    const selected = page.getByTestId("list-pane").locator("[data-selected='true']");
+    await expect(selected).toHaveAttribute("data-tagpinned", "false");
+    await page.keyboard.press("/");
+    await page.keyboard.press("Shift+P"); // Shift+P while in search state
+    await page.keyboard.press("Escape");
+    await expect(selected).toHaveAttribute("data-tagpinned", "true");
+  });
+
+  test("Shift+P does not affect pin in editing state", async ({ page }) => {
+    await page.keyboard.press("j");
+    const selected = page.getByTestId("list-pane").locator("[data-selected='true']");
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("Shift+P"); // should type 'P', not toggle tag-pin
+    await page.keyboard.press("Escape");
+    await expect(selected).toHaveAttribute("data-tagpinned", "false");
+  });
+
+  test("pin and tag-pin are independent", async ({ page }) => {
+    await page.keyboard.press("j");
+    const selected = page.getByTestId("list-pane").locator("[data-selected='true']");
+    await page.keyboard.press("p"); // pin only
+    await expect(selected).toHaveAttribute("data-pinned", "true");
+    await expect(selected).toHaveAttribute("data-tagpinned", "false");
+    await page.keyboard.press("Shift+P"); // tag-pin only
+    await expect(selected).toHaveAttribute("data-pinned", "true");
+    await expect(selected).toHaveAttribute("data-tagpinned", "true");
+    await page.keyboard.press("p"); // unpin — tag-pin stays
     await expect(selected).toHaveAttribute("data-pinned", "false");
+    await expect(selected).toHaveAttribute("data-tagpinned", "true");
   });
 });
 
 test.describe("Tag-Pinning", () => {
-  test("pinned note appears first when its first tag is the active filter", async ({ page }) => {
-    // Create a note whose first tag is #guide and pin it
+  test("tag-pinned note appears first when its first tag is the active filter", async ({ page }) => {
     await page.keyboard.press("c");
     const editor = page.getByTestId("content-pane").getByRole("textbox");
-    await editor.fill("#guide Pinned client note");
+    await editor.fill("#guide Tag-pinned client note");
     await page.keyboard.press("Escape");
-    await page.keyboard.press("p"); // pin it
+    await page.keyboard.press("Shift+P"); // Shift+P — tag-pin
 
-    // Filter by #guide
     await page.keyboard.press("/");
     const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
     await searchInput.fill("#guide");
     await page.keyboard.press("Enter");
 
-    // Tag-pinned note should be first
     const first = page.getByTestId("list-pane").getByTestId("note-item").first();
-    await expect(first.getByTestId("note-item-title")).toContainText("#guide Pinned client note");
+    await expect(first.getByTestId("note-item-title")).toContainText("#guide Tag-pinned client note");
   });
 
-  test("pinned note does NOT sort first when filter is a non-primary tag", async ({ page }) => {
-    // Create a note tag-pinned for #guide (first tag = #guide, pinned)
+  test("tag-pinned note does NOT sort first when filter is a non-primary tag", async ({ page }) => {
     await page.keyboard.press("c");
     const editor = page.getByTestId("content-pane").getByRole("textbox");
     await editor.fill("#guide Primary guide note");
     await page.keyboard.press("Escape");
-    await page.keyboard.press("p"); // tag-pinned for #guide
+    await page.keyboard.press("Shift+P"); // Shift+P — tag-pinned for #guide
 
-    // Create a newer note pinned but with #guide as a secondary tag
     await page.keyboard.press("c");
     const editor2 = page.getByTestId("content-pane").getByRole("textbox");
     await editor2.fill("#client-acme overview #guide");
     await page.keyboard.press("Escape");
-    await page.keyboard.press("p"); // pinned but NOT tag-pinned for #guide
+    await page.keyboard.press("Shift+P"); // tag-pinned but first tag is #client-acme not #guide
 
-    // Filter by #guide
     await page.keyboard.press("/");
     const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
     await searchInput.fill("#guide");
     await page.keyboard.press("Enter");
 
-    // #guide Primary guide note must be first despite the newer #client-acme note also being pinned
     const first = page.getByTestId("list-pane").getByTestId("note-item").first();
     await expect(first.getByTestId("note-item-title")).toContainText("#guide Primary guide note");
   });
 
-  test("unpinned note with matching first tag does not get tag-pin boost", async ({ page }) => {
-    // Create two notes with #guide as first tag; pin neither
+  test("note without tag-pin does not get sort boost even with matching first tag", async ({ page }) => {
     await page.keyboard.press("c");
     let editor = page.getByTestId("content-pane").getByRole("textbox");
     await editor.fill("#guide Note A");
@@ -1062,46 +1109,62 @@ test.describe("Tag-Pinning", () => {
     await editor.fill("#guide Note B");
     await page.keyboard.press("Escape");
 
-    // Filter by #guide
     await page.keyboard.press("/");
     const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
     await searchInput.fill("#guide");
     await page.keyboard.press("Enter");
 
-    // Neither should be forced first by tag-pinning; both appear but order is by recency
     const items = page.getByTestId("list-pane").getByTestId("note-item");
-    const count = await items.count();
-    expect(count).toBeGreaterThanOrEqual(2);
-    // Verify no item has data-pinned="true" among those two
+    expect(await items.count()).toBeGreaterThanOrEqual(2);
     const titleA = items.filter({ hasText: "Note A" });
     const titleB = items.filter({ hasText: "Note B" });
-    await expect(titleA).toHaveAttribute("data-pinned", "false");
-    await expect(titleB).toHaveAttribute("data-pinned", "false");
+    await expect(titleA).toHaveAttribute("data-tagpinned", "false");
+    await expect(titleB).toHaveAttribute("data-tagpinned", "false");
   });
 
-  test("tag-pinned note is still first after other notes are added", async ({ page }) => {
-    // Create and pin a note for #ideas
+  test("tag-pinned note is still first after newer notes are added", async ({ page }) => {
     await page.keyboard.press("c");
     const editor = page.getByTestId("content-pane").getByRole("textbox");
     await editor.fill("#ideas Master ideas note");
     await page.keyboard.press("Escape");
-    await page.keyboard.press("p");
+    await page.keyboard.press("Shift+P"); // Shift+P
 
-    // Add another #ideas note (newer, would normally sort first)
     await page.keyboard.press("c");
     const editor2 = page.getByTestId("content-pane").getByRole("textbox");
     await editor2.fill("#ideas Newer ideas note");
     await page.keyboard.press("Escape");
 
-    // Filter by #ideas
     await page.keyboard.press("/");
     const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
     await searchInput.fill("#ideas");
     await page.keyboard.press("Enter");
 
-    // Tag-pinned note must still be first despite newer note existing
     const first = page.getByTestId("list-pane").getByTestId("note-item").first();
     await expect(first.getByTestId("note-item-title")).toContainText("#ideas Master ideas note");
+  });
+
+  test("regularly pinned note does NOT sort to top in search/filter mode", async ({ page }) => {
+    // Pin a note with p (regular pin)
+    await page.keyboard.press("c");
+    const editor = page.getByTestId("content-pane").getByRole("textbox");
+    await editor.fill("#guide Pinned but not tag-pinned");
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("p"); // regular pin only
+
+    // Create a newer note
+    await page.keyboard.press("c");
+    const editor2 = page.getByTestId("content-pane").getByRole("textbox");
+    await editor2.fill("#guide Newer note");
+    await page.keyboard.press("Escape");
+
+    await page.keyboard.press("/");
+    const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
+    await searchInput.fill("#guide");
+    await page.keyboard.press("Enter");
+
+    // Newer note should be first since pinned note has no tag-pin boost in search
+    const first = page.getByTestId("list-pane").getByTestId("note-item").first();
+    await expect(first.getByTestId("note-item-title")).toContainText("#guide Newer note");
   });
 });
 
@@ -1156,7 +1219,7 @@ test.describe("Pinning Indicators", () => {
     const editor = page.getByTestId("content-pane").getByRole("textbox");
     await editor.fill("#ideas Master ideas note");
     await page.keyboard.press("Escape");
-    await page.keyboard.press("p"); // pin — first tag is #ideas
+    await page.keyboard.press("Shift+P"); // Shift+P — tag-pin
 
     await page.keyboard.press("/");
     const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
@@ -1165,16 +1228,19 @@ test.describe("Pinning Indicators", () => {
 
     const first = page.getByTestId("list-pane").getByTestId("note-item").first();
     const title = await first.getByTestId("note-item-title").textContent();
-    expect(title).toMatch(/○/); // pinned
-    expect(title).toMatch(/#/); // tag-pinned
+    expect(title).toMatch(/#/); // tag-pinned indicator
   });
 
-  test("tag-pinned note switches from # back to ○ when filter is cleared", async ({ page }) => {
+  test("tag-pinned note always shows # indicator regardless of active filter", async ({ page }) => {
     await page.keyboard.press("c");
     const editor = page.getByTestId("content-pane").getByRole("textbox");
     await editor.fill("#ideas Master ideas note");
     await page.keyboard.press("Escape");
-    await page.keyboard.press("p");
+    await page.keyboard.press("Shift+P"); // tag-pin
+
+    const noteItem = page.getByTestId("list-pane").getByTestId("note-item").filter({ hasText: "Master ideas note" });
+    // # indicator visible in idle mode
+    await expect(noteItem.locator('span').filter({ hasText: '#' }).first()).toBeVisible();
 
     // Apply filter
     await page.keyboard.press("/");
@@ -1182,17 +1248,13 @@ test.describe("Pinning Indicators", () => {
     await searchInput.fill("#ideas");
     await page.keyboard.press("Enter");
 
-    const noteItem = page.getByTestId("list-pane").getByTestId("note-item").filter({ hasText: "Master ideas note" });
-    const titleWithFilter = await noteItem.getByTestId("note-item-title").textContent();
-    expect(titleWithFilter).toMatch(/○/); // pinned
-    expect(titleWithFilter).toMatch(/#/); // tag-pinned
+    // Still visible with filter
+    await expect(noteItem.locator('span').filter({ hasText: '#' }).first()).toBeVisible();
 
-    // Clear filter
+    // Clear filter — still visible
     await page.keyboard.press("Escape");
     await page.keyboard.press("Escape");
-
-    const titleNoFilter = await noteItem.getByTestId("note-item-title").textContent();
-    expect(titleNoFilter).toMatch(/^○/);
+    await expect(noteItem.locator('span').filter({ hasText: '#' }).first()).toBeVisible();
   });
 });
 
@@ -1438,12 +1500,13 @@ test.describe("Dynamic divider", () => {
 });
 
 test.describe("Dual pin indicators", () => {
-  test("pinned note with matching first tag shows both ○ and # when filter contains that tag", async ({ page }) => {
+  test("note with both pin and tag-pin shows ○ and # when filter matches first tag", async ({ page }) => {
     await page.keyboard.press("c");
     const editor = page.getByTestId("content-pane").getByRole("textbox");
     await editor.fill("#ideas dual indicator test");
     await page.keyboard.press("Escape");
-    await page.keyboard.press("p"); // pin it
+    await page.keyboard.press("p");   // regular pin → ○
+    await page.keyboard.press("Shift+P");   // Shift+P tag-pin → #
 
     await page.keyboard.press("/");
     const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
@@ -1461,7 +1524,7 @@ test.describe("Dual pin indicators", () => {
     const editor = page.getByTestId("content-pane").getByRole("textbox");
     await editor.fill("#ideas multi term test");
     await page.keyboard.press("Escape");
-    await page.keyboard.press("p");
+    await page.keyboard.press("Shift+P"); // Shift+P — tag-pin
 
     await page.keyboard.press("/");
     const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
@@ -1473,8 +1536,8 @@ test.describe("Dual pin indicators", () => {
     expect(title).toMatch(/#/); // tag-pinned even with multi-term query
   });
 
-  test("pinned note without matching tag shows only ○ (no #)", async ({ page }) => {
-    // First note in INITIAL_NOTES is pinned with #intro; filter by #guide
+  test("pinned-only note shows ○ but no # in search", async ({ page }) => {
+    // First note in INITIAL_NOTES is pinned (not tag-pinned); filter by #guide
     await page.keyboard.press("/");
     const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
     await searchInput.fill("#guide");
@@ -1484,7 +1547,6 @@ test.describe("Dual pin indicators", () => {
     if (await pinnedItems.count() > 0) {
       const title = await pinnedItems.first().getByTestId("note-item-title").textContent();
       expect(title).toMatch(/○/);
-      // Should NOT have # as tag-pin indicator (first char or after ○)
       expect(title!.replace("○", "")).not.toMatch(/^#/);
     }
   });

--- a/spec.md
+++ b/spec.md
@@ -30,7 +30,8 @@ The app consists of three panes:
 | id        | string   | Unique identifier                    |
 | content   | string   | Full note content                    |
 | title     | string   | Derived — see Note List Item Display |
-| pinned    | boolean  | Whether the note is pinned to top    |
+| pinned    | boolean  | Pinned to top of list in idle mode   |
+| tagPinned | boolean  | Pinned to top of filtered results when first tag matches query |
 | createdAt | datetime | Creation timestamp                   |
 | updatedAt | datetime | Last modification timestamp          |
 
@@ -89,7 +90,8 @@ SS → 'Esc Esc'              → IS    (message filter cleared)
 | `t` then `n`     | IS         | Apply `#tasks-nearterm` filter, select first matching note |
 | `t` then `l`     | IS         | Apply `#tasks-longterm` filter, select first matching note |
 | `t` then `m`     | IS         | Open task-move overlay to assign a `#tasks-*` tag to the selected note |
-| `p`              | IS         | Toggle pin on selected note                                 |
+| `p`              | IS, SS     | Toggle regular pin on selected note (idle-mode top only)    |
+| `Shift+P`        | IS, SS     | Toggle tag-pin on selected note (search-mode top when first tag matches) |
 | `?`              | IS         | Show keyboard shortcuts help overlay                        |
 | `d` then `d`     | IS         | Open `https://notedude.app/donate` in a new browser tab    |
 | `d` then `m`     | IS         | Toggle dark/light mode                                      |
@@ -184,29 +186,41 @@ Pressing `?` in Idle State shows a full-screen overlay listing all keyboard shor
 
 ## Pinning Indicators
 
-Each note item in the List Pane shows a bullet character before its title when pinned:
+Each note item in the List Pane shows a bullet character before its title based on its pin state:
 
 | Condition | Bullet | Character |
 |-----------|--------|-----------|
-| Pinned, no active tag filter (or filter doesn't match first tag) | Circle | `○` |
-| Tag-pinned for the active tag filter (pinned + first tag matches) | Small hash | `#` (smaller, muted) |
-| Not pinned | _(none)_ | |
+| `pinned === true` | Circle | `○` |
+| `tagPinned === true` | Small hash | `#` (smaller, muted) |
+| Neither | _(none)_ | |
 
-- `#` replaces `○` — a note shows at most one indicator at a time
-- The bullet is part of the title line display only; it does not affect note content
+- Both indicators can appear simultaneously when a note is both pinned and tag-pinned with a matching filter
+- Bullets are part of the title line display only; they do not affect note content
 
-## Tag-Pinning
+## Pinning
 
-When a note is pinned (via `p`) and a tag filter is active, the note sorts to the **top of filtered results** if its **first tag** matches the active filter tag.
+Two independent pin modes exist, toggled via separate shortcuts:
 
+### Regular pin (`p`)
+- Toggles `pinned` on the selected note
+- Works in Idle State and Search State
+- Pinned notes sort to the **top of the list in idle mode only**
+- In search/filter mode, pinned notes behave like regular notes — no sort boost
+
+### Tag-pin (`Shift+P`)
+- Toggles `tagPinned` on the selected note
+- Works in Idle State and Search State
+- Tag-pinned notes sort to the **top of filtered results** when the note's **first tag** appears in the active search query
+- Has no effect on sort order in idle mode (no active filter)
+
+### Tag-pin details
 - **First tag** = the first `#word` token in the note's content
-- A note is "tag-pinned for tag X" when: `pinned === true` AND `firstTag === X`
-- In a tag-filtered list, tag-pinned notes appear before all others; ties broken by `updatedAt` descending
-- Outside of tag filtering (no filter, or plain-text filter), sort order is unchanged: pinned notes above unpinned, newest first within each group
+- A note is "active tag-pinned" when: `tagPinned === true` AND `firstTag` is in the active query tags
+- In a tag-filtered list, active tag-pinned notes appear before all others; ties broken by `updatedAt` descending
 - One note can be tag-pinned for at most one tag (its first tag) — deliberate primary-context authorship
 
 ### Example
-A note `#client-acme Status update...` that is pinned will appear first when the filter is `#client-acme`, but not when filtering by `#meeting` even if `#meeting` also appears in the note.
+A note `#client-acme Status update...` with `tagPinned = true` will appear first when the filter is `#client-acme`, but not when filtering by `#meeting`. In idle mode (no filter) it sorts like any other note.
 
 ## Behaviors
 
@@ -214,6 +228,7 @@ A note `#client-acme Status update...` that is pinned will appear first when the
 - **New note**: Created with blank content; Content Pane starts empty for fresh typing
 - **Filter**: When a message filter is active, only matching notes appear in the List Pane. Filtering is incremental — the note list updates live as the user types in the search bar
 - **Filter clear**: Pressing Esc twice (within 500ms) in IS or SS clears the filter and shows all notes
-- **Pinning**: Pinned notes always appear at the top of the List Pane
+- **Pinning**: Pinned notes appear at the top of the List Pane in idle mode. In search/filter mode they behave like regular notes
+- **Tag-pinning**: Tag-pinned notes appear at the top of filtered results when their first tag matches the active search query
 - **Auto-save**: Edits are saved automatically on state transition out of ES
 - **Welcome note**: On first login (Firestore returns zero notes), a welcome note is automatically created with content `"Greetings\nPress ? for keyboard shortcuts."`. It is created only once — subsequent logins with existing notes do not re-create it. The welcome note appears at the top of the note list.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,6 +7,7 @@ interface Note {
   id: string;
   content: string;
   pinned: boolean;
+  tagPinned: boolean;
   createdAt: number;
   updatedAt: number;
   isNew?: boolean; // true until the user edits content for the first time
@@ -15,13 +16,13 @@ interface Note {
 type AppState = "idle" | "editing" | "search";
 
 const INITIAL_NOTES: Note[] = [
-  { id: "1", content: "Welcome to notedude #intro\nYour keyboard-driven note app.", pinned: true, createdAt: 1, updatedAt: 1 },
-  { id: "2", content: "Getting started #intro #guide\nPress 'c' to create a new note.\nPress '/' to search.", pinned: false, createdAt: 2, updatedAt: 2 },
-  { id: "3", content: "Keyboard shortcuts #guide\nEnter to edit, Esc to save.", pinned: false, createdAt: 3, updatedAt: 3 },
-  { id: "4", content: "Tips #tips\nUse 'j' and 'k' to navigate.", pinned: false, createdAt: 4, updatedAt: 4 },
-  { id: "5", content: "Projects #project\nOrganize notes by project.", pinned: false, createdAt: 5, updatedAt: 5 },
-  { id: "6", content: "Archive #archive\nOld notes go here.", pinned: false, createdAt: 6, updatedAt: 6 },
-  { id: "7", content: "Ideas #ideas\nCapture them here.", pinned: false, createdAt: 7, updatedAt: 7 },
+  { id: "1", content: "Welcome to notedude #intro\nYour keyboard-driven note app.", pinned: true, tagPinned: false, createdAt: 1, updatedAt: 1 },
+  { id: "2", content: "Getting started #intro #guide\nPress 'c' to create a new note.\nPress '/' to search.", pinned: false, tagPinned: false, createdAt: 2, updatedAt: 2 },
+  { id: "3", content: "Keyboard shortcuts #guide\nEnter to edit, Esc to save.", pinned: false, tagPinned: false, createdAt: 3, updatedAt: 3 },
+  { id: "4", content: "Tips #tips\nUse 'j' and 'k' to navigate.", pinned: false, tagPinned: false, createdAt: 4, updatedAt: 4 },
+  { id: "5", content: "Projects #project\nOrganize notes by project.", pinned: false, tagPinned: false, createdAt: 5, updatedAt: 5 },
+  { id: "6", content: "Archive #archive\nOld notes go here.", pinned: false, tagPinned: false, createdAt: 6, updatedAt: 6 },
+  { id: "7", content: "Ideas #ideas\nCapture them here.", pinned: false, tagPinned: false, createdAt: 7, updatedAt: 7 },
 ];
 
 function getNoteTitle(note: Note): string {
@@ -104,6 +105,7 @@ const DEMO_WELCOME: Note = {
   id: "demo-welcome",
   content: "Demo mode - data is stored locally only.\n\nPress ? for keyboard shortcuts.",
   pinned: true,
+  tagPinned: false,
   createdAt: 1,
   updatedAt: 1,
 };
@@ -180,17 +182,14 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
   })();
 
   function getPinBullets(note: Note): { circle: boolean; hash: boolean } {
-    if (!note.pinned) return { circle: false, hash: false };
-    const firstTag = note.content.match(/#[\w-]+/)?.[0]?.toLowerCase();
-    const hash = !!firstTag && activeQueryTags.has(firstTag);
-    return { circle: true, hash };
+    return { circle: note.pinned, hash: note.tagPinned };
   }
 
   const displayed = (() => {
-    const sorted = sortNotes(notes);
     const query = activeQuery;
-    if (!query.trim()) return sorted;
-    const filtered = sorted.filter((n) => {
+    if (!query.trim()) return sortNotes(notes);
+    // In search/filter mode: no pinned boost — sort by recency only, then tag-pin on top
+    const filtered = [...notes].sort((a, b) => b.updatedAt - a.updatedAt).filter((n) => {
       const lower = n.content.toLowerCase();
       const parts = query.trim().split(/\s+/);
       return parts.every((part) => {
@@ -201,16 +200,14 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
         return lower.includes(part.toLowerCase());
       });
     });
-    // Tag-pinning: if the query mentions any tags, re-sort so that pinned notes
-    // whose first tag appears in the query come first.
     if (activeQueryTags.size === 0) return filtered;
-    const isTagPinned = (n: Note) => {
+    const isActiveTagPinned = (n: Note) => {
       const firstTag = n.content.match(/#[\w-]+/)?.[0]?.toLowerCase();
-      return n.pinned && !!firstTag && activeQueryTags.has(firstTag);
+      return n.tagPinned && !!firstTag && activeQueryTags.has(firstTag);
     };
     return [...filtered].sort((a, b) => {
-      const aTp = isTagPinned(a);
-      const bTp = isTagPinned(b);
+      const aTp = isActiveTagPinned(a);
+      const bTp = isActiveTagPinned(b);
       if (aTp && !bTp) return -1;
       if (!aTp && bTp) return 1;
       return b.updatedAt - a.updatedAt;
@@ -350,7 +347,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
         if (!welcomeSeededRef.current && remoteNotes.length === 0) {
           welcomeSeededRef.current = true;
           const now = Date.now();
-          const welcome: Note = { id: crypto.randomUUID(), content: "Greetings\nPress ? for keyboard shortcuts.", pinned: false, createdAt: now, updatedAt: now };
+          const welcome: Note = { id: crypto.randomUUID(), content: "Greetings\nPress ? for keyboard shortcuts.", pinned: false, tagPinned: false, createdAt: now, updatedAt: now };
           saveNote(uid, welcome);
           setNotes([welcome]);
           setSynced(true);
@@ -472,6 +469,28 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
         return;
       }
 
+      // p / Shift+P work in idle and search states
+      if (appState === "idle" || appState === "search") {
+        if (e.key === "p" && !e.shiftKey) {
+          e.preventDefault();
+          if (selectedId) {
+            const updated = notes.find((n) => n.id === selectedId);
+            setNotes((prev) => prev.map((n) => n.id === selectedId ? { ...n, pinned: !n.pinned } : n));
+            if (uid && !demo && updated) saveNote(uid, { ...updated, pinned: !updated.pinned });
+          }
+          return;
+        }
+        if (e.key === "P" && e.shiftKey) {
+          e.preventDefault();
+          if (selectedId) {
+            const updated = notes.find((n) => n.id === selectedId);
+            setNotes((prev) => prev.map((n) => n.id === selectedId ? { ...n, tagPinned: !n.tagPinned } : n));
+            if (uid && !demo && updated) saveNote(uid, { ...updated, tagPinned: !updated.tagPinned });
+          }
+          return;
+        }
+      }
+
       if (appState === "idle") {
         if (e.key === "c") {
           e.preventDefault();
@@ -479,6 +498,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
             id: crypto.randomUUID(),
             content: "",
             pinned: false,
+            tagPinned: false,
             createdAt: Date.now(),
             updatedAt: Date.now(),
             isNew: true,
@@ -538,13 +558,6 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
         if (e.key === "?") {
           e.preventDefault();
           setShowHelp(true);
-          return;
-        }
-        if (e.key === "p") {
-          e.preventDefault();
-          if (selectedId) {
-            setNotes((prev) => prev.map((n) => n.id === selectedId ? { ...n, pinned: !n.pinned } : n));
-          }
           return;
         }
         if (e.key === "Y") {
@@ -774,6 +787,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
               data-testid="note-item"
               data-selected={note.id === selectedId ? "true" : "false"}
               data-pinned={note.pinned ? "true" : "false"}
+              data-tagpinned={note.tagPinned ? "true" : "false"}
               onClick={() => setSelectedId(note.id)}
               style={{
                 padding: 8,
@@ -863,9 +877,10 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
                 ["Esc Esc", "clear filter"],
               ]],
               ["pinning", [
-                ["p",       "pin / tag-pin note to top"],
+                ["p",       "pin note to top (idle mode)"],
+                ["Shift+P", "tag-pin note (top of search results when first tag matches)"],
                 ["○",       "indicator: pinned"],
-                ["#",       "indicator: tag-pinned (pinned note whose first tag matches search)"],
+                ["#",       "indicator: tag-pinned (first tag matches active search)"],
               ]],
               ["to do list", [
                 ["t → i",   "#tasks-inbox"],

--- a/src/lib/notes.ts
+++ b/src/lib/notes.ts
@@ -13,6 +13,7 @@ export interface NoteData {
   id: string;
   content: string;
   pinned: boolean;
+  tagPinned: boolean;
   createdAt: number;
   updatedAt: number;
   isNew?: boolean;
@@ -40,6 +41,7 @@ export function subscribeToNotes(
             id: d.id,
             content: data.content ?? "",
             pinned: data.pinned ?? false,
+            tagPinned: data.tagPinned ?? false,
             createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toMillis() : data.createdAt ?? 0,
             updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toMillis() : data.updatedAt ?? 0,
           };
@@ -56,6 +58,7 @@ export function saveNote(uid: string, note: NoteData) {
   setDoc(ref, {
     content: note.content,
     pinned: note.pinned,
+    tagPinned: note.tagPinned,
     createdAt: note.createdAt,
     updatedAt: serverTimestamp(),
   }).catch((err) => console.error("Failed to save note:", err));


### PR DESCRIPTION
## Summary
- `p` — regular pin: note floats to top of list in **idle mode only**; behaves like a normal note in search
- `Shift+P` — tag-pin: note floats to top of **filtered results** when its first tag appears in the active search query; no effect in idle mode
- Both shortcuts work in idle and search states
- Notes can be pinned, tag-pinned, both, or neither (independent toggles)
- New `tagPinned` field added to Note data model and Firestore
- Indicators: `○` = pinned, `#` = tag-pinned with matching active filter (both can show simultaneously)
- Updated spec.md, keyboard shortcuts help overlay, and all E2E tests

## Test plan
- [x] 5 new Tag-Pin Toggle (Shift+P) tests
- [x] 5 updated Tag-Pinning tests (including new: pinned note does NOT sort first in search)
- [x] 3 updated Dual pin indicators tests
- [x] 2 updated Pinning Indicators tests
- [x] 146 tests passing, 3 pre-existing failures unrelated to this change

Closes #60