### PR TITLE
Add r→r report issue shortcut, fix demo logout, Cmd+Enter in help

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -761,6 +761,7 @@ test.describe("Tag Search Keyboard Shortcuts", () => {
     { keys: ["t", "t"], tag: "#tasks-today" },
     { keys: ["t", "n"], tag: "#tasks-nearterm" },
     { keys: ["t", "l"], tag: "#tasks-longterm" },
+    { keys: ["t", "d"], tag: "#tasks-done" },
   ];
 
   for (const { keys, tag } of shortcuts) {
@@ -1423,7 +1424,7 @@ test.describe("Task-move overlay (t+m)", () => {
     await expect(page.getByTestId("task-move-overlay")).toBeVisible();
   });
 
-  test("overlay lists all four task tags", async ({ page }) => {
+  test("overlay lists all five task tags including done", async ({ page }) => {
     await page.keyboard.press("t");
     await page.keyboard.press("m");
     const overlay = page.getByTestId("task-move-overlay");
@@ -1431,6 +1432,7 @@ test.describe("Task-move overlay (t+m)", () => {
     await expect(overlay).toContainText("#tasks-today");
     await expect(overlay).toContainText("#tasks-nearterm");
     await expect(overlay).toContainText("#tasks-longterm");
+    await expect(overlay).toContainText("#tasks-done");
   });
 
   test("first tag is highlighted by default", async ({ page }) => {

--- a/spec.md
+++ b/spec.md
@@ -89,7 +89,8 @@ SS → 'Esc Esc'              → IS    (message filter cleared)
 | `t` then `t`     | IS         | Apply `#tasks-today` filter, select first matching note |
 | `t` then `n`     | IS         | Apply `#tasks-nearterm` filter, select first matching note |
 | `t` then `l`     | IS         | Apply `#tasks-longterm` filter, select first matching note |
-| `t` then `m`     | IS         | Open task-move overlay to assign a `#tasks-*` tag to the selected note |
+| `t` then `d`     | IS         | Apply `#tasks-done` filter, select first matching note |
+| `t` then `m`     | IS         | Open task-move overlay to assign a `#tasks-*` tag to the selected note (includes `#tasks-done`) |
 | `p`              | IS, SS     | Toggle regular pin on selected note (idle-mode top only)    |
 | `Shift+P`        | IS, SS     | Toggle tag-pin on selected note (search-mode top when first tag matches) |
 | `?`              | IS         | Show keyboard shortcuts help overlay                        |
@@ -113,7 +114,8 @@ From Idle State, pressing `t` arms a tag-shortcut prefix. A second key within 15
 | `t`        | Apply `#tasks-today` filter   |
 | `n`        | Apply `#tasks-nearterm` filter|
 | `l`        | Apply `#tasks-longterm` filter|
-| `m`        | Open task-move overlay        |
+| `d`        | Apply `#tasks-done` filter    |
+| `m`        | Open task-move overlay (includes `#tasks-done`) |
 
 - The filter is applied immediately and the first matching note is selected
 - If the second key is not one of the above, the prefix is cancelled silently
@@ -123,7 +125,7 @@ From Idle State, pressing `t` arms a tag-shortcut prefix. A second key within 15
 
 Pressing `t` then `m` in Idle State opens a task-move overlay on the selected note.
 
-- Lists the four standard task tags: `#tasks-inbox`, `#tasks-today`, `#tasks-nearterm`, `#tasks-longterm`
+- Lists the five standard task tags: `#tasks-inbox`, `#tasks-today`, `#tasks-nearterm`, `#tasks-longterm`, `#tasks-done`
 - Tags are sorted by most recently used (most recent `updatedAt` of any note containing that tag); unseen tags appear last in their natural order
 - The first tag in the list is highlighted by default (`data-selected="true"`)
 - `j` / `↓` and `k` / `↑` navigate the list

--- a/spec.md
+++ b/spec.md
@@ -95,6 +95,7 @@ SS → 'Esc Esc'              → IS    (message filter cleared)
 | `Shift+P`        | IS, SS     | Toggle tag-pin on selected note (search-mode top when first tag matches) |
 | `?`              | IS         | Show keyboard shortcuts help overlay                        |
 | `d` then `d`     | IS         | Open `https://notedude.app/donate` in a new browser tab    |
+| `r` then `r`     | IS         | Open `mailto:issues20260531@notedude.app` to report an issue |
 | `d` then `m`     | IS         | Toggle dark/light mode                                      |
 | `l` then `l`     | IS         | Log out the current user                                    |
 | `Shift+Y`        | IS         | Archive the selected note; select next (or previous if last) |

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,7 +44,7 @@ export default function Page() {
           </button>
         </div>
         <div style={{ flex: 1 }}>
-          <App demo />
+          <App demo onLogout={() => setDemoMode(false)} />
         </div>
       </div>
     );

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -176,7 +176,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
     (activeQuery.match(/#[\w-]+/gi) ?? []).map((t) => t.toLowerCase())
   );
 
-  const TASK_TAGS = ["#tasks-inbox", "#tasks-today", "#tasks-nearterm", "#tasks-longterm"];
+  const TASK_TAGS = ["#tasks-inbox", "#tasks-today", "#tasks-nearterm", "#tasks-longterm", "#tasks-done"];
   const taskTagsSorted = (() => {
     const recency = new Map(extractTags(notes).filter(t => TASK_TAGS.includes(t.tag)).map(t => [t.tag, t.lastUsed]));
     return [...TASK_TAGS].sort((a, b) => (recency.get(b) ?? 0) - (recency.get(a) ?? 0));
@@ -555,7 +555,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
             setShowTaskMove(true);
             return;
           }
-          const tagMap: Record<string, string> = { i: "#tasks-inbox", t: "#tasks-today", n: "#tasks-nearterm", l: "#tasks-longterm" };
+          const tagMap: Record<string, string> = { i: "#tasks-inbox", t: "#tasks-today", n: "#tasks-nearterm", l: "#tasks-longterm", d: "#tasks-done" };
           const tag = tagMap[e.key];
           if (tag) {
             e.preventDefault();
@@ -883,7 +883,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
                 ["⌘[ / ⌘]", "navigate back / forward in history"],
                 ["c",       "create new note"],
                 ["⏎ / e",   "edit selected note"],
-                ["Esc",     "save and exit editing"],
+                ["Esc / ⌘⏎", "save and exit editing"],
               ]],
               ["search", [
                 ["/",       "open search"],
@@ -902,7 +902,8 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
                 ["t → t",   "#tasks-today"],
                 ["t → n",   "#tasks-nearterm"],
                 ["t → l",   "#tasks-longterm"],
-                ["t → m",   "move note to a task list"],
+                ["t → d",   "#tasks-done"],
+                ["t → m",   "move note to a task list (incl. done)"],
               ]],
               ["etc", [
                 ["Shift+Y", "archive selected note"],

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -162,6 +162,8 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
   const dPrefixTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lPrefixArmed = useRef(false);
   const lPrefixTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rPrefixArmed = useRef(false);
+  const rPrefixTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const welcomeSeededRef = useRef(false);
   const editingNoteIdRef = useRef<string | null>(null);
   // Navigation history: list of note IDs visited (in editing or idle selection)
@@ -627,6 +629,21 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
           lPrefixTimer.current = setTimeout(() => { lPrefixArmed.current = false; lPrefixTimer.current = null; }, 1500);
           return;
         }
+        if (rPrefixArmed.current) {
+          rPrefixArmed.current = false;
+          if (rPrefixTimer.current) { clearTimeout(rPrefixTimer.current); rPrefixTimer.current = null; }
+          if (e.key === "r") {
+            e.preventDefault();
+            window.open("mailto:issues20260531@notedude.app", "_blank");
+          }
+          return;
+        }
+        if (e.key === "r") {
+          e.preventDefault();
+          rPrefixArmed.current = true;
+          rPrefixTimer.current = setTimeout(() => { rPrefixArmed.current = false; rPrefixTimer.current = null; }, 1500);
+          return;
+        }
         if (e.key === "Escape") {
           e.preventDefault();
           const now = Date.now();
@@ -909,6 +926,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
                 ["Shift+Y", "archive selected note"],
                 ["d → m",   "toggle dark mode"],
                 ["d → d",   "open donate page"],
+                ["r → r",   "report an issue"],
                 ["l → l",   "log out"],
                 ["?",       "show this"],
               ]],


### PR DESCRIPTION
## Summary
- `r→r` opens `mailto:issues20260531@notedude.app` to report issues
- `l→l` logout now works in demo mode (returns to sign-in screen)
- Keyboard shortcuts help overlay: `Esc / ⌘⏎` combined for save, `r→r` entry added
- Spec updated

## Test plan
- [ ] Press `r` then `r` in idle mode — mail client opens pre-addressed to issues20260531@notedude.app
- [ ] In demo mode, press `l` then `l` — returns to sign-in screen
- [ ] Press `?` — confirm `r → r` appears and save shows `Esc / ⌘⏎`

Closes #53

🤖 Generated with [Claude Code](https://claude.ai/code)