### PR TITLE
Redesign archive, fix search shortcuts, recent-search tag suggestions

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -288,14 +288,16 @@ test.describe("Filtering Behavior", () => {
     const countBefore = await items.count();
     expect(countBefore).toBeGreaterThanOrEqual(2);
 
-    // Archive the first filtered note
+    // Archive the first filtered note — it moves to the archived section at the bottom
     await page.keyboard.press("Shift+Y");
-    await expect(items).toHaveCount(countBefore - 1);
+    await expect(page.getByTestId("archived-divider")).toBeVisible();
+    // Total note-item count stays the same (archived note is still shown, just below the divider)
+    await expect(items).toHaveCount(countBefore);
 
-    // The next selected note should still be in the filtered results
+    // The next selected note should be a non-archived #guide note
     const contentPane = page.getByTestId("content-pane");
     await expect(contentPane).toContainText("#guide");
-    await expect(items.first()).toHaveAttribute("data-selected", "true");
+    await expect(contentPane).not.toContainText("#archived");
   });
 });
 
@@ -558,45 +560,61 @@ test.describe("Tag Search", () => {
     await expect(tags).toHaveCount(6);
   });
 
-  test("top 5 most recent tags appear before the separator", async ({ page }) => {
-    await page.keyboard.press("/");
+  test("top section shows recently searched tags before the separator", async ({ page }) => {
     const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
-    await searchInput.fill("#");
 
+    // Search for #guide and #intro to populate search history
+    await page.keyboard.press("/");
+    await searchInput.fill("#guide");
+    await page.keyboard.press("Enter");
+    await page.keyboard.press("/");
+    await searchInput.fill("#intro");
+    await page.keyboard.press("Enter");
+
+    // Open tag dropdown — #intro (most recent search) should be first, then #guide
+    await page.keyboard.press("/");
+    await searchInput.fill("#");
     const tags = page.getByTestId("tag-item");
-    // Seed order by recency: #ideas(7) #archive(6) #project(5) #tips(4) #guide(3)
-    await expect(tags.nth(0)).toContainText("#ideas");
-    await expect(tags.nth(1)).toContainText("#archive");
-    await expect(tags.nth(2)).toContainText("#project");
-    await expect(tags.nth(3)).toContainText("#tips");
-    await expect(tags.nth(4)).toContainText("#guide");
+    await expect(tags.nth(0)).toContainText("#intro");
+    await expect(tags.nth(1)).toContainText("#guide");
   });
 
   test("remaining tags appear after the separator in alphabetical order", async ({ page }) => {
-    await page.keyboard.press("/");
     const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
-    await searchInput.fill("#");
 
+    // Search one tag to create a top section
+    await page.keyboard.press("/");
+    await searchInput.fill("#guide");
+    await page.keyboard.press("Enter");
+
+    // Open dropdown — non-searched tags should appear alphabetically after separator
+    await page.keyboard.press("/");
+    await searchInput.fill("#");
     const tags = page.getByTestId("tag-item");
-    // #intro is the 6th tag, alphabetically after the separator
-    await expect(tags.nth(5)).toContainText("#intro");
+    // #guide is the recent section; rest are alphabetical: #archive, #ideas, #intro, #project, #tips
+    await expect(tags.nth(1)).toContainText("#archive");
   });
 
-  test("a separator is shown between recent and alphabetical sections when there are more than 5 tags", async ({ page }) => {
-    await page.keyboard.press("/");
+  test("a separator is shown between recent and alphabetical sections when search history exists", async ({ page }) => {
     const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
-    await searchInput.fill("#");
 
+    // Seed one tag into search history
+    await page.keyboard.press("/");
+    await searchInput.fill("#guide");
+    await page.keyboard.press("Enter");
+
+    // Open dropdown — separator should appear between recent (#guide) and the rest
+    await page.keyboard.press("/");
+    await searchInput.fill("#");
     await expect(page.getByTestId("tag-separator")).toBeVisible();
   });
 
-  test("no separator is shown when there are 5 or fewer tags", async ({ page }) => {
+  test("no separator is shown when there are no recently searched tags", async ({ page }) => {
     await page.keyboard.press("/");
     const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
-    // Filter to only 3 tags (those starting with 'a', 'g', 'i' won't all be 5+)
-    await searchInput.fill("#i"); // matches #ideas and #intro = 2 tags
+    await searchInput.fill("#"); // all 6 tags, but no search history
 
-    await expect(page.getByTestId("tag-item")).toHaveCount(2);
+    await expect(page.getByTestId("tag-item")).toHaveCount(6);
     await expect(page.getByTestId("tag-separator")).not.toBeVisible();
   });
 
@@ -1034,17 +1052,15 @@ test.describe("Pin Toggle", () => {
     await expect(selected).toHaveAttribute("data-pinned", "false");
   });
 
-  test("'p' toggles pin in search state", async ({ page }) => {
+  test("'p' does not toggle pin while search input is focused", async ({ page }) => {
     await page.keyboard.press("j");
     const selected = page.getByTestId("list-pane").locator("[data-selected='true']");
     await expect(selected).toHaveAttribute("data-pinned", "false");
     await page.keyboard.press("/");
-    await page.keyboard.press("Escape"); // enter search then back to idle
-    await page.keyboard.press("/");
-    // while in search state, press p
+    // while search input is focused (search state), press p — should not pin
     await page.keyboard.press("p");
     await page.keyboard.press("Escape");
-    await expect(selected).toHaveAttribute("data-pinned", "true");
+    await expect(selected).toHaveAttribute("data-pinned", "false");
   });
 });
 
@@ -1066,14 +1082,14 @@ test.describe("Tag-Pin Toggle (Shift+P)", () => {
     await expect(selected).toHaveAttribute("data-tagpinned", "false");
   });
 
-  test("Shift+P works in search state", async ({ page }) => {
+  test("Shift+P does not toggle tag-pin while search input is focused", async ({ page }) => {
     await page.keyboard.press("j");
     const selected = page.getByTestId("list-pane").locator("[data-selected='true']");
     await expect(selected).toHaveAttribute("data-tagpinned", "false");
     await page.keyboard.press("/");
-    await page.keyboard.press("Shift+P"); // Shift+P while in search state
+    await page.keyboard.press("Shift+P"); // Shift+P while search input is focused — should not tag-pin
     await page.keyboard.press("Escape");
-    await expect(selected).toHaveAttribute("data-tagpinned", "true");
+    await expect(selected).toHaveAttribute("data-tagpinned", "false");
   });
 
   test("Shift+P does not affect pin in editing state", async ({ page }) => {

--- a/spec.md
+++ b/spec.md
@@ -91,14 +91,14 @@ SS → 'Esc Esc'              → IS    (message filter cleared)
 | `t` then `l`     | IS         | Apply `#tasks-longterm` filter, select first matching note |
 | `t` then `d`     | IS         | Apply `#tasks-done` filter, select first matching note |
 | `t` then `m`     | IS         | Open task-move overlay to assign a `#tasks-*` tag to the selected note (includes `#tasks-done`) |
-| `p`              | IS, SS     | Toggle regular pin on selected note (idle-mode top only)    |
-| `Shift+P`        | IS, SS     | Toggle tag-pin on selected note (search-mode top when first tag matches) |
+| `p`              | IS         | Toggle regular pin on selected note (idle-mode top only)    |
+| `Shift+P`        | IS         | Toggle tag-pin on selected note (search-mode top when first tag matches) |
 | `?`              | IS         | Show keyboard shortcuts help overlay                        |
 | `d` then `d`     | IS         | Open `https://notedude.app/donate` in a new browser tab    |
 | `r` then `r`     | IS         | Open `mailto:issues20260531@notedude.app` to report an issue |
 | `d` then `m`     | IS         | Toggle dark/light mode                                      |
 | `l` then `l`     | IS         | Log out the current user                                    |
-| `Shift+Y`        | IS         | Archive the selected note; select next (or previous if last) |
+| `Shift+Y`        | IS         | Archive the selected note (appends `#archived` tag, hidden in idle mode); select next note |
 | `Esc`            | ES         | Save edits, return to idle                  |
 | `Cmd/Ctrl+Enter` | ES         | Save edits, return to idle                  |
 | `Enter`          | SS         | Apply filter, return to idle                |
@@ -136,6 +136,17 @@ Pressing `t` then `m` in Idle State opens a task-move overlay on the selected no
   - The note is saved immediately
 - `Esc` dismisses the overlay without changes
 - Has `data-testid="task-move-overlay"`
+
+## Archive
+
+Pressing `Shift+Y` in Idle State archives the selected note:
+
+- Appends ` #archived` to the note's content
+- The note remains in the data store — it is not deleted
+- Archived notes are **hidden in Idle State** (not shown in the list)
+- In Search State, archived notes that match the query appear at the **bottom of the list**, below a labelled divider (`data-testid="archived-divider"`)
+- Archived notes are displayed at 50% opacity to distinguish them from active notes
+- After archiving, the next note in the displayed list is selected (or previous if it was the last)
 
 ## Dark Mode
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 import { subscribeToNotes, saveNote, archiveNote, type NoteData } from "../lib/notes";
 
 interface Note {
@@ -145,8 +145,13 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
   const [saveFlashId, setSaveFlashId] = useState<string | null>(null);
   const [showTaskMove, setShowTaskMove] = useState(false);
   const [taskMoveIndex, setTaskMoveIndex] = useState(0);
+  const [recentSearchTags, setRecentSearchTags] = useState<string[]>([]);
   useEffect(() => {
     if (localStorage.getItem("theme") === "dark") setDarkMode(true);
+    try {
+      const stored = localStorage.getItem("recentSearchTags");
+      if (stored) setRecentSearchTags(JSON.parse(stored));
+    } catch { /* ignore */ }
   }, []);
 
   const [dividerRows, setDividerRows] = useState(35);
@@ -188,11 +193,12 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
     return { circle: note.pinned, hash: note.tagPinned };
   }
 
-  const displayed = (() => {
+  const isArchived = (n: Note) => /#archived(?=[\s,.]|$)/i.test(n.content);
+
+  const { displayed, displayedArchived } = (() => {
     const query = activeQuery;
-    if (!query.trim()) return sortNotes(notes);
-    // In search/filter mode: no pinned boost — sort by recency only, then tag-pin on top
-    const filtered = [...notes].sort((a, b) => b.updatedAt - a.updatedAt).filter((n) => {
+    const matchesQuery = (n: Note) => {
+      if (!query.trim()) return true;
       const lower = n.content.toLowerCase();
       const parts = query.trim().split(/\s+/);
       return parts.every((part) => {
@@ -202,19 +208,26 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
         }
         return lower.includes(part.toLowerCase());
       });
-    });
-    if (activeQueryTags.size === 0) return filtered;
+    };
+    if (!query.trim()) {
+      return { displayed: sortNotes(notes.filter((n) => !isArchived(n))), displayedArchived: [] };
+    }
+    const sorted = [...notes].sort((a, b) => b.updatedAt - a.updatedAt);
     const isActiveTagPinned = (n: Note) => {
       const firstTag = n.content.match(/#[\w-]+/)?.[0]?.toLowerCase();
       return n.tagPinned && !!firstTag && activeQueryTags.has(firstTag);
     };
-    return [...filtered].sort((a, b) => {
+    const applyTagPin = (arr: Note[]) => activeQueryTags.size === 0 ? arr : [...arr].sort((a, b) => {
       const aTp = isActiveTagPinned(a);
       const bTp = isActiveTagPinned(b);
       if (aTp && !bTp) return -1;
       if (!aTp && bTp) return 1;
       return b.updatedAt - a.updatedAt;
     });
+    return {
+      displayed: applyTagPin(sorted.filter((n) => !isArchived(n) && matchesQuery(n))),
+      displayedArchived: sorted.filter((n) => isArchived(n) && matchesQuery(n)),
+    };
   })();
 
   const selectedNote = notes.find((n) => n.id === selectedId);
@@ -225,9 +238,12 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
     const allTags = extractTags(notes);
     const query = filterQuery.toLowerCase().slice(1);
     const matched = query ? allTags.filter((t) => t.tag.slice(1).startsWith(query)) : allTags;
-    const recent = matched.slice(0, 5);
-    const rest = matched.slice(5).sort((a, b) => a.tag.localeCompare(b.tag));
-    return { filteredTags: [...recent, ...rest], recentTagCount: recent.length };
+    const matchedSet = new Set(matched.map((t) => t.tag));
+    // Top section: recently searched tags that match the current query prefix, in recency order
+    const recentMatched = recentSearchTags.filter((tag) => matchedSet.has(tag)).slice(0, 5);
+    const recentSet = new Set(recentMatched);
+    const rest = matched.filter((t) => !recentSet.has(t.tag)).sort((a, b) => a.tag.localeCompare(b.tag));
+    return { filteredTags: [...recentMatched.map((tag) => ({ tag, lastUsed: 0 })), ...rest], recentTagCount: recentMatched.length };
   })();
 
   const insertTag = useCallback((tag: string) => {
@@ -236,12 +252,21 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
     searchRef.current?.focus();
   }, []);
 
+  const recordSearchTag = useCallback((tag: string) => {
+    setRecentSearchTags((prev) => {
+      const next = [tag, ...prev.filter((t) => t !== tag)].slice(0, 20);
+      localStorage.setItem("recentSearchTags", JSON.stringify(next));
+      return next;
+    });
+  }, []);
+
   const selectTag = useCallback((tag: string) => {
+    recordSearchTag(tag);
     setActiveFilter(tag);
     setFilterQuery("");
     setSelectedTagIndex(-1);
     setAppState("idle");
-  }, []);
+  }, [recordSearchTag]);
 
   // Editor tag completion
   const editorHashToken = (() => {
@@ -399,10 +424,11 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
 
   // Keep selectedId in sync with displayed list
   useEffect(() => {
-    if (displayed.length > 0 && !displayed.some((n) => n.id === selectedId)) {
-      setSelectedId(displayed[0].id);
+    const allDisplayed = [...displayed, ...displayedArchived];
+    if (allDisplayed.length > 0 && !allDisplayed.some((n) => n.id === selectedId)) {
+      setSelectedId(displayed[0]?.id ?? displayedArchived[0]?.id ?? "");
     }
-  }, [displayed, selectedId]);
+  }, [displayed, displayedArchived, selectedId]);
 
   // Auto-focus app on mount
   useEffect(() => {
@@ -483,8 +509,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
         return;
       }
 
-      // p / Shift+P work in idle and search states
-      if (appState === "idle" || appState === "search") {
+      if (appState === "idle") {
         if (e.key === "p" && !e.shiftKey) {
           e.preventDefault();
           if (selectedId) {
@@ -503,9 +528,6 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
           }
           return;
         }
-      }
-
-      if (appState === "idle") {
         if (e.key === "c") {
           e.preventDefault();
           const newNote: Note = {
@@ -578,10 +600,15 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
           e.preventDefault();
           if (selectedId) {
             const idx = displayed.findIndex((n) => n.id === selectedId);
-            const next = displayed[idx + 1] ?? displayed[idx - 1] ?? null;
-            const noteToArchive = notes.find((n) => n.id === selectedId);
-            if (uid && !demo && noteToArchive) archiveNote(uid, selectedId, noteToArchive.content);
-            setNotes((prev) => prev.filter((n) => n.id !== selectedId));
+            const next = displayed[idx + 1] ?? displayed[idx - 1] ?? displayed[0] ?? null;
+            setNotes((prev) => prev.map((n) => {
+              if (n.id !== selectedId) return n;
+              const sep = n.content.endsWith("\n") || n.content === "" ? "" : " ";
+              const newContent = n.content + sep + "#archived";
+              const updated = { ...n, content: newContent, updatedAt: Date.now() };
+              if (uid && !demo) archiveNote(uid, updated);
+              return updated;
+            }));
             setSelectedId(next?.id ?? "");
           }
           return;
@@ -724,6 +751,8 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
         }
         if (e.key === "Enter") {
           e.preventDefault();
+          const tags = (filterQuery.match(/#[\w-]+/g) ?? []).map((t) => t.toLowerCase());
+          tags.forEach(recordSearchTag);
           setActiveFilter(filterQuery);
           setAppState("idle");
           return;
@@ -787,7 +816,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
         <div data-testid="tag-dropdown" style={{ padding: "4px 8px", background: darkMode ? "#2a2a2a" : "#f5f5f5" }}>
           {filteredTags.map(({ tag }, i) => (
             <div key={tag}>
-              {i === recentTagCount && recentTagCount < filteredTags.length && (
+              {i === recentTagCount && recentTagCount > 0 && recentTagCount < filteredTags.length && (
                 <div data-testid="tag-separator" style={{ borderTop: `1px solid ${darkMode ? "#444" : "#ccc"}`, margin: "4px 0" }} />
               )}
               <div
@@ -809,33 +838,43 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
       <div style={{ display: "flex", flex: 1, overflow: "hidden" }}>
         {/* List Pane */}
         <div ref={listPaneRef} data-testid="list-pane" style={{ width: 250, overflowY: "auto" }}>
-          {displayed.map((note) => (
-            <div
-              key={note.id}
-              data-testid="note-item"
-              data-selected={note.id === selectedId ? "true" : "false"}
-              data-pinned={note.pinned ? "true" : "false"}
-              data-tagpinned={note.tagPinned ? "true" : "false"}
-              data-flash={note.id === saveFlashId ? "true" : "false"}
-              onClick={() => setSelectedId(note.id)}
-              style={{
-                padding: 8,
-                cursor: "pointer",
-                background: note.id === saveFlashId
-                  ? (darkMode ? "#1a7a1a" : "#6fcf7f")
-                  : note.id === selectedId ? (darkMode ? "#3a3a6a" : "#e0e7ff") : "transparent",
-                transition: "background 0.3s ease",
-              }}
-            >
-              <div data-testid="note-item-title" style={{ fontWeight: 400, fontSize: 14, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                {(() => { const b = getPinBullets(note); return (<>{b.circle && <span style={{ marginRight: 2 }}>○</span>}{b.hash && <span style={{ fontSize: "0.75em", opacity: 0.6, marginRight: 2 }}>#</span>}</>); })()}
-                {getNoteTitle(note)}
-              </div>
-              <div data-testid="note-item-meta" style={{ fontSize: 12, color: darkMode ? "#999" : "#666", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                {formatTimestamp(note.createdAt)} | {getNoteMetaSnippet(note)}
-              </div>
-            </div>
-          ))}
+          {[...displayed, ...displayedArchived].map((note, i) => {
+            const isArchivedDivider = i === displayed.length && displayedArchived.length > 0;
+            return (
+              <React.Fragment key={note.id}>
+                {isArchivedDivider && (
+                  <div data-testid="archived-divider" style={{ fontSize: 10, opacity: 0.4, textTransform: "uppercase", letterSpacing: "0.08em", padding: "6px 8px 2px", userSelect: "none" }}>
+                    archived
+                  </div>
+                )}
+                <div
+                  data-testid="note-item"
+                  data-selected={note.id === selectedId ? "true" : "false"}
+                  data-pinned={note.pinned ? "true" : "false"}
+                  data-tagpinned={note.tagPinned ? "true" : "false"}
+                  data-flash={note.id === saveFlashId ? "true" : "false"}
+                  onClick={() => setSelectedId(note.id)}
+                  style={{
+                    padding: 8,
+                    cursor: "pointer",
+                    background: note.id === saveFlashId
+                      ? (darkMode ? "#1a7a1a" : "#6fcf7f")
+                      : note.id === selectedId ? (darkMode ? "#3a3a6a" : "#e0e7ff") : "transparent",
+                    transition: "background 0.3s ease",
+                    opacity: isArchived(note) ? 0.5 : 1,
+                  }}
+                >
+                  <div data-testid="note-item-title" style={{ fontWeight: 400, fontSize: 14, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                    {(() => { const b = getPinBullets(note); return (<>{b.circle && <span style={{ marginRight: 2 }}>○</span>}{b.hash && <span style={{ fontSize: "0.75em", opacity: 0.6, marginRight: 2 }}>#</span>}</>); })()}
+                    {getNoteTitle(note)}
+                  </div>
+                  <div data-testid="note-item-meta" style={{ fontSize: 12, color: darkMode ? "#999" : "#666", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                    {formatTimestamp(note.createdAt)} | {getNoteMetaSnippet(note)}
+                  </div>
+                </div>
+              </React.Fragment>
+            );
+          })}
         </div>
 
         <div data-testid="divider" style={{ overflow: "hidden", whiteSpace: "pre", color: darkMode ? "#555" : "#000", lineHeight: "1.4", userSelect: "none", width: "1ch", fontSize: 14 }}>
@@ -923,7 +962,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
                 ["t → m",   "move note to a task list (incl. done)"],
               ]],
               ["etc", [
-                ["Shift+Y", "archive selected note"],
+                ["Shift+Y", "archive note (tags #archived, hidden in idle)"],
                 ["d → m",   "toggle dark mode"],
                 ["d → d",   "open donate page"],
                 ["r → r",   "report an issue"],

--- a/src/lib/notes.ts
+++ b/src/lib/notes.ts
@@ -23,7 +23,7 @@ function userNotesCol(uid: string) {
   return collection(db, "users", uid, "notes");
 }
 
-/** Subscribe to all non-archived notes for a user. Returns an unsubscribe function. */
+/** Subscribe to all notes for a user (including archived). Returns an unsubscribe function. */
 export function subscribeToNotes(
   uid: string,
   onNotes: (notes: NoteData[]) => void,
@@ -34,7 +34,6 @@ export function subscribeToNotes(
     { includeMetadataChanges: false },
     (snap) => {
       const notes: NoteData[] = snap.docs
-        .filter((d) => !d.data().archived)
         .map((d) => {
           const data = d.data();
           return {
@@ -64,10 +63,11 @@ export function saveNote(uid: string, note: NoteData) {
   }).catch((err) => console.error("Failed to save note:", err));
 }
 
-/** Archive a note (soft-delete). Appends #archived tag and sets archived:true. Fire-and-forget. */
-export function archiveNote(uid: string, noteId: string, currentContent: string) {
-  const ref = doc(db, "users", uid, "notes", noteId);
-  const content = currentContent + "\n#archived";
-  updateDoc(ref, { archived: true, content, updatedAt: serverTimestamp() })
+/** Archive a note by appending #archived tag. Fire-and-forget. */
+export function archiveNote(uid: string, note: NoteData) {
+  const ref = doc(db, "users", uid, "notes", note.id);
+  const sep = note.content.endsWith("\n") || note.content === "" ? "" : " ";
+  const content = note.content + sep + "#archived";
+  updateDoc(ref, { content, updatedAt: serverTimestamp() })
     .catch((err) => console.error("Failed to archive note:", err));
 }


### PR DESCRIPTION
## Summary
- **Archive redesign** (closes #49): `Shift+Y` now appends `#archived` to the note instead of deleting it. Archived notes are hidden in idle mode and appear at the bottom of search results below a labeled divider at 50% opacity.
- **Search input shortcuts** (closes #65): `p` and `Shift+P` no longer fire while the search input is focused — they only work in idle mode.
- **Recent-search tag suggestions** (closes #66): The tag dropdown top section now shows the most recently *searched* tags (persisted in localStorage) instead of most recently *used* tags. Non-recent tags appear alphabetically below a separator.

## Test plan
- [x] Archive: note tagged with #archived, hidden in idle, visible at bottom in search with divider
- [x] Search input: typing `p` in search field types normally, doesn't pin
- [x] Tag suggestions: recently searched tags appear first in order
- [x] 150 passing, 4 pre-existing failures unrelated to this change

🤖 Generated with [Claude Code](https://claude.ai/code)