### PR TITLE
Security audit fixes: firestore rules, MCP archive, headers, SKIP_AUTH guard

### DIFF
--- a/e2e/firebase-roundtrip.spec.ts
+++ b/e2e/firebase-roundtrip.spec.ts
@@ -101,6 +101,69 @@ test("ll shortcut logs out the user", async ({ page, baseURL }) => {
   await expect(page.getByRole("button", { name: /sign in/i })).toBeVisible();
 });
 
+type WriteResult = { ok: boolean; code?: string };
+
+async function rawWriteNote(page: Page, noteId: string, data: Record<string, unknown>): Promise<WriteResult> {
+  return page.evaluate(
+    ([id, payload]) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__testWriteNote(id, payload) as Promise<WriteResult>,
+    [noteId, data] as [string, Record<string, unknown>]
+  );
+}
+
+test("security rules: a valid note write is accepted", async ({ page, baseURL }) => {
+  await loadAndSignIn(page, baseURL!);
+  const res = await rawWriteNote(page, "valid-note", {
+    content: "hello",
+    pinned: false,
+    tagPinned: false,
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+  });
+  expect(res.ok).toBe(true);
+});
+
+test("security rules: a write with an unknown field is rejected", async ({ page, baseURL }) => {
+  await loadAndSignIn(page, baseURL!);
+  const res = await rawWriteNote(page, "evil-field-note", {
+    content: "hello",
+    pinned: false,
+    tagPinned: false,
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    archived: true, // not in the field whitelist
+  });
+  expect(res.ok).toBe(false);
+  expect(res.code).toContain("permission-denied");
+});
+
+test("security rules: oversized content is rejected", async ({ page, baseURL }) => {
+  await loadAndSignIn(page, baseURL!);
+  const res = await rawWriteNote(page, "huge-note", {
+    content: "x".repeat(100_001), // exceeds the 100k cap
+    pinned: false,
+    tagPinned: false,
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+  });
+  expect(res.ok).toBe(false);
+  expect(res.code).toContain("permission-denied");
+});
+
+test("security rules: a wrong-typed field is rejected", async ({ page, baseURL }) => {
+  await loadAndSignIn(page, baseURL!);
+  const res = await rawWriteNote(page, "bad-type-note", {
+    content: "hello",
+    pinned: "yes", // should be a boolean
+    tagPinned: false,
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+  });
+  expect(res.ok).toBe(false);
+  expect(res.code).toContain("permission-denied");
+});
+
 test("note is visible in a new browser session (cross-session sync)", async ({ page, browser, baseURL }) => {
   // Session 1: create a note
   await loadAndSignIn(page, baseURL!);

--- a/firebase.json
+++ b/firebase.json
@@ -7,6 +7,18 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          { "key": "X-Content-Type-Options", "value": "nosniff" },
+          { "key": "X-Frame-Options", "value": "DENY" },
+          { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+          { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
+          { "key": "Permissions-Policy", "value": "geolocation=(), microphone=(), camera=()" }
+        ]
+      }
     ]
   },
   "firestore": {

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,8 +2,26 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
+
+    function isOwner(userId) {
+      return request.auth != null && request.auth.uid == userId;
+    }
+
+    // A note may only contain these fields, with these types, and content is
+    // capped at 100k characters. Rejects unknown fields and oversized payloads.
+    function isValidNote(data) {
+      return data.keys().hasOnly(['content', 'pinned', 'tagPinned', 'createdAt', 'updatedAt'])
+        && data.content is string
+        && data.content.size() <= 100000
+        && data.pinned is bool
+        && data.tagPinned is bool
+        && data.createdAt is number
+        && (data.updatedAt is timestamp || data.updatedAt is number);
+    }
+
     match /users/{userId}/notes/{noteId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, delete: if isOwner(userId);
+      allow create, update: if isOwner(userId) && isValidNote(request.resource.data);
     }
   }
 }

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -176,14 +176,21 @@ server.tool(
 
 server.tool(
   "delete_note",
-  "Archive a note by id (soft-delete — sets archived:true, hidden from the app but not permanently removed).",
+  "Archive a note by id (soft-delete — appends a #archived tag so the note is hidden in the app's idle view but not permanently removed).",
   { id: z.string().describe("Note id to archive") },
   async ({ id }) => {
     const ref = notesCol().doc(id);
     const snap = await ref.get();
     if (!snap.exists) return { content: [{ type: "text", text: `Note ${id} not found.` }] };
-    const title = (snap.data()?.content ?? "").split("\n")[0] || "untitled";
-    await ref.update({ archived: true, updatedAt: admin.firestore.FieldValue.serverTimestamp() });
+    const current: string = snap.data()?.content ?? "";
+    const title = current.split("\n")[0] || "untitled";
+    // The app hides notes by the #archived tag in content (see archiveNote), not by a field.
+    if (/#archived(?=[\s,.]|$)/i.test(current)) {
+      return { content: [{ type: "text", text: `Note ${id} ("${title}") is already archived.` }] };
+    }
+    const sep = current.endsWith("\n") || current === "" ? "" : " ";
+    const content = current + sep + "#archived";
+    await ref.update({ content, updatedAt: admin.firestore.FieldValue.serverTimestamp() });
     return { content: [{ type: "text", text: `Archived note ${id}: "${title}"` }] };
   }
 );

--- a/spec.md
+++ b/spec.md
@@ -249,3 +249,32 @@ A note `#client-acme Status update...` with `tagPinned = true` will appear first
 - **Tag-pinning**: Tag-pinned notes appear at the top of filtered results when their first tag matches the active search query
 - **Auto-save**: Edits are saved automatically on state transition out of ES
 - **Welcome note**: On first login (Firestore returns zero notes), a welcome note is automatically created with content `"Greetings\nPress ? for keyboard shortcuts."`. It is created only once — subsequent logins with existing notes do not re-create it. The welcome note appears at the top of the note list.
+
+## Persistence & Security
+
+### Deployment model
+- The web app is a **static export** (`output: "export"`) served by Firebase Hosting. There is no Next.js server runtime, so the app has **no API routes** — all reads/writes go directly from the browser to Firestore via the Firebase client SDK, authorized by Firestore Security Rules.
+- The only privileged/server-side surface is the **MCP server** (`mcp/`), which uses the Firebase Admin SDK with a service account and bypasses Security Rules. It is run locally by the note owner, not exposed to the public.
+
+### Firestore Security Rules
+Notes live at `users/{userId}/notes/{noteId}`.
+- **Read / delete**: allowed only when `request.auth.uid == userId` (the owner).
+- **Create / update**: allowed only for the owner **and** when the written document passes field validation:
+  - Only these fields may be present: `content`, `pinned`, `tagPinned`, `createdAt`, `updatedAt` (no other keys).
+  - `content` is a string of at most **100,000** characters.
+  - `pinned` and `tagPinned` are booleans; `createdAt` is a number; `updatedAt` is a timestamp or number.
+- Writes that include unknown fields or oversized content are rejected with `permission-denied`.
+
+### Authentication bypass guard
+- `NEXT_PUBLIC_SKIP_AUTH=true` renders the app without the sign-in screen for local development. This bypass is **disabled in production builds** (`NODE_ENV === "production"`), so a leaked or mis-set env var can never disable authentication on the deployed site.
+
+### Security headers
+Firebase Hosting serves these response headers on all routes (configured in `firebase.json`, since Next's `headers()` does not apply to a static export):
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains`
+- `Permissions-Policy: geolocation=(), microphone=(), camera=()`
+
+### MCP archive consistency
+- The MCP `delete_note` tool performs a **soft archive** consistent with the app: it appends a `#archived` tag to the note's content (matching `Shift+Y` / `archiveNote()`), rather than setting a separate field. This ensures notes archived via MCP are hidden in the app's Idle State exactly like notes archived in-app. It is idempotent — a note already tagged `#archived` is left unchanged.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,10 @@ import App from "@/components/App";
 import { useAuth } from "@/lib/useAuth";
 import { useEffect, useState } from "react";
 
-const SKIP_AUTH = process.env.NEXT_PUBLIC_SKIP_AUTH === "true";
+// Local-dev convenience only — auth can never be bypassed in a production build,
+// even if NEXT_PUBLIC_SKIP_AUTH leaks into the deployed environment.
+const SKIP_AUTH =
+  process.env.NEXT_PUBLIC_SKIP_AUTH === "true" && process.env.NODE_ENV !== "production";
 
 export default function Page() {
   const { user, loading, login, logout } = useAuth();

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -6,6 +6,8 @@ import {
   persistentMultipleTabManager,
   connectFirestoreEmulator,
   memoryLocalCache,
+  doc,
+  setDoc,
 } from "firebase/firestore";
 
 const firebaseConfig = {
@@ -39,5 +41,20 @@ if (useEmulator) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).__testSignIn = (email: string, password: string) =>
       signInWithEmailAndPassword(auth, email, password);
+    // Raw write to the signed-in user's own notes collection, used to exercise
+    // Firestore Security Rules (field whitelist + size cap). Returns the rule
+    // outcome instead of throwing so tests can assert on it.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__testWriteNote = async (noteId: string, data: Record<string, unknown>) => {
+      const user = auth.currentUser;
+      if (!user) return { ok: false, code: "no-current-user" };
+      try {
+        await setDoc(doc(db, "users", user.uid, "notes", noteId), data);
+        return { ok: true };
+      } catch (e) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return { ok: false, code: (e as any)?.code ?? String(e) };
+      }
+    };
   }
 }


### PR DESCRIPTION
Closes #71.

> **Stacked on #70** (`fix-paste-numbered-lists`). The base is set to that branch so this diff shows only the security changes. Retarget to `main` once #70 merges. The fixes depend on the redesigned tag-only archive that lives on that branch.

## What & why

**1. Tighten `firestore.rules` (#3)** — the real security win. Create/update now require the owner **and** a validated document: only `content`, `pinned`, `tagPinned`, `createdAt`, `updatedAt` may be present (correct types), and `content` is capped at 100k chars. Unknown fields and oversized payloads are rejected with `permission-denied`. Owner-only read/delete kept.

**2. MCP `delete_note` (#7)** — it set `archived: true`, but the app hides archived notes by the `#archived` *tag in content* (see `archiveNote`), so MCP "archive" never actually hid the note. Now it appends `#archived` (idempotent), matching `Shift+Y`.

**3. Dead `/api/notes` + `firebase-admin.ts` (#2)** — unhostable under `output: "export"` (no server runtime). Discarded along with the root `firebase-admin` dep; server-side note access is already covered by the MCP server. (These were untracked experiments, so they don't appear as deletions in the diff.)

**4. Security headers (#5)** — added to `firebase.json` hosting (Next `headers()` doesn't apply to a static export): `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Strict-Transport-Security`, `Permissions-Policy`.

**5. `SKIP_AUTH` guard (#4)** — `NEXT_PUBLIC_SKIP_AUTH` is now gated behind `NODE_ENV !== "production"`, so a leaked env var can't disable auth in a prod build.

## Tests
New emulator-backed rules tests in `firebase-roundtrip.spec.ts`: valid write accepted; unknown-field, oversized-content, and wrong-typed-field writes rejected. Helper `__testWriteNote` (emulator-only) added to `firebase.ts`.

- ✅ `FIREBASE_ROUNDTRIP=true` suite: **9/9 pass** (5 existing roundtrip + 4 new rules tests) — confirms tightened rules don't break legit create/update/archive/welcome writes.
- ✅ Chromium app suite: **150 pass / 4 fail**. The 4 failures (`app.spec.ts:353, 420, 425, 1243`) **pre-exist on the base branch** — verified by reproducing them with this PR's changes stashed — and are unrelated to the security work.

`spec.md` gains a **Persistence & Security** section documenting the deployment model, rules, headers, auth guard, and MCP archive consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)