### PR TITLE
Update footer nbino link to nbino.tech

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1614,8 +1614,8 @@ test.describe("Footer", () => {
     await expect(footer).toBeVisible();
   });
 
-  test("footer nbino is a mailto link", async ({ page }) => {
-    const link = page.locator('a[href="mailto:nbinoinfo@gmail.com"]');
+  test("footer nbino links to nbino.tech", async ({ page }) => {
+    const link = page.locator('a[href="https://nbino.tech"]');
     await expect(link).toBeVisible();
     await expect(link).toContainText("nbino");
   });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1002,7 +1002,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
         </div>
       </div>
       <div style={{ padding: "8px", textAlign: "center", fontSize: 12, color: "#888", userSelect: "none" }}>
-        notedude &bull; an <a href="mailto:nbinoinfo@gmail.com" target="_blank" rel="noopener noreferrer" style={{ color: "#888", textDecoration: "underline" }}>nbino</a> production
+        notedude &bull; an <a href="https://nbino.tech" target="_blank" rel="noopener noreferrer" style={{ color: "#888", textDecoration: "underline" }}>nbino</a> production
       </div>
       {showHelp && (
         <div


### PR DESCRIPTION
Closes #80.

Footer "nbino" credit now links to `https://nbino.tech` (was `mailto:nbinoinfo@gmail.com`). Opens in a new tab with `rel="noopener noreferrer"`.

- `src/components/App.tsx` — footer `<a href>` updated
- `e2e/app.spec.ts` — "Footer" test updated to assert the new link

Footer tests pass (2/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)