### PR TITLE
Block mobile browsers on login page

### DIFF
--- a/e2e/mobile-block.spec.ts
+++ b/e2e/mobile-block.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+const MOBILE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+
+test.describe("Mobile Browser Block", () => {
+  test("mobile user-agent shows block message instead of login UI", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({ userAgent: MOBILE_UA });
+    const page = await context.newPage();
+    await page.goto("/");
+
+    await expect(page.getByTestId("mobile-block")).toBeVisible();
+    await expect(page.getByTestId("mobile-block")).toContainText(
+      "does not support mobile browsers"
+    );
+
+    // Login buttons should NOT be visible
+    await expect(page.getByText("sign in with google")).not.toBeVisible();
+    await expect(page.getByText("emo mode")).not.toBeVisible();
+
+    await context.close();
+  });
+
+  test("desktop user-agent shows normal login page", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByTestId("mobile-block")).not.toBeVisible();
+    await expect(page.getByText("sign in with google")).toBeVisible();
+  });
+
+  test("/test page is not affected by mobile block", async ({ browser }) => {
+    const context = await browser.newContext({ userAgent: MOBILE_UA });
+    const page = await context.newPage();
+    await page.goto("/test");
+
+    // The app should load normally
+    await expect(page.getByTestId("app")).toBeVisible();
+    await expect(page.getByTestId("mobile-block")).not.toBeVisible();
+
+    await context.close();
+  });
+});

--- a/spec.md
+++ b/spec.md
@@ -4,6 +4,15 @@
 
 A keyboard-driven note-taking app combining Google Keep's keyboard navigation with Apple Notes' layout and features. Built with Next.js.
 
+## Mobile Browser Block
+
+This app is designed for desktop keyboards and does not support mobile browsers. On the login page (`/`), the app checks the user-agent string for mobile devices. If a mobile browser is detected:
+
+- The login UI (sign-in button, demo mode button) is **not rendered**
+- A block message is shown instead: "notedude is a keyboard-driven app and does not support mobile browsers."
+- The message container has `data-testid="mobile-block"`
+- The `/test` page is unaffected by this check
+
 ## UI Layout
 
 The app consists of three panes:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,9 +9,18 @@ import { useEffect, useState } from "react";
 const SKIP_AUTH =
   process.env.NEXT_PUBLIC_SKIP_AUTH === "true" && process.env.NODE_ENV !== "production";
 
+function useIsMobile(): boolean | null {
+  const [isMobile, setIsMobile] = useState<boolean | null>(null);
+  useEffect(() => {
+    setIsMobile(/Android|iPhone|iPad|iPod|Mobile|webOS/i.test(navigator.userAgent));
+  }, []);
+  return isMobile;
+}
+
 export default function Page() {
   const { user, loading, login, logout } = useAuth();
   const [demoMode, setDemoMode] = useState(false);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     if (loading || user || demoMode) return;
@@ -33,8 +42,16 @@ export default function Page() {
     );
   }
 
-  if (loading) {
+  if (loading || isMobile === null) {
     return <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", fontFamily: "'Fira Code', monospace" }}>loading...</div>;
+  }
+
+  if (isMobile) {
+    return (
+      <div data-testid="mobile-block" style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", fontFamily: "'Fira Code', monospace", padding: 32, textAlign: "center" }}>
+        notedude is a keyboard-driven app and does not support mobile browsers.
+      </div>
+    );
   }
 
   if (demoMode) {


### PR DESCRIPTION
## Summary

- Mobile browsers now see a block message instead of the login UI: "notedude is a keyboard-driven app and does not support mobile browsers."
- Detection uses `navigator.userAgent` checked on mount (avoids SSR hydration mismatch)
- The `/test` page is unaffected

## Changes

- **spec.md**: Added "Mobile Browser Block" section
- **src/app/page.tsx**: Added `useIsMobile` hook and block screen before login UI
- **e2e/mobile-block.spec.ts**: 3 new E2E tests (mobile block visible, desktop login visible, /test unaffected)

## Test plan

- [x] Mobile user-agent shows block message, no sign-in/demo buttons
- [x] Desktop user-agent shows normal login page
- [x] `/test` page loads normally with mobile user-agent

Closes #82

https://claude.ai/code/session_01Q4QJTsSNvg9jCdSoxBBgnu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4QJTsSNvg9jCdSoxBBgnu)_