### PR TITLE
Add global ⌘/ (Ctrl+/) shortcut for keyboard help (closes #85)

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1323,6 +1323,7 @@ test.describe("Help Overlay", () => {
     await page.keyboard.press("?");
     const overlay = page.getByTestId("help-overlay");
     await expect(overlay).toContainText("?");
+    await expect(overlay).toContainText("⌘/");
     await expect(overlay).toContainText("j");
     await expect(overlay).toContainText("k");
     await expect(overlay).toContainText("p");
@@ -1362,6 +1363,35 @@ test.describe("Help Overlay", () => {
     await searchInput.pressSequentially("?");
     await expect(page.getByTestId("app")).toHaveAttribute("data-state", "search");
     await expect(page.getByTestId("help-overlay")).not.toBeVisible();
+  });
+
+  test("⌘/ shows the help overlay from idle state", async ({ page }) => {
+    await page.keyboard.press("ControlOrMeta+/");
+    await expect(page.getByTestId("help-overlay")).toBeVisible();
+  });
+
+  test("⌘/ shows the help overlay from editing state", async ({ page }) => {
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+    await page.keyboard.press("ControlOrMeta+/");
+    await expect(page.getByTestId("help-overlay")).toBeVisible();
+  });
+
+  test("⌘/ shows the help overlay from search state", async ({ page }) => {
+    await page.keyboard.press("/");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "search");
+    await page.keyboard.press("ControlOrMeta+/");
+    await expect(page.getByTestId("help-overlay")).toBeVisible();
+  });
+
+  test("plain '/' still types into the editor (⌘/ does not hijack the slash key)", async ({ page }) => {
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+    const editor = page.getByTestId("content-pane").getByRole("textbox");
+    await editor.fill("");
+    await editor.pressSequentially("a/b");
+    await expect(page.getByTestId("help-overlay")).not.toBeVisible();
+    await expect(editor).toHaveValue("a/b");
   });
 });
 

--- a/e2e/firebase-roundtrip.spec.ts
+++ b/e2e/firebase-roundtrip.spec.ts
@@ -68,7 +68,27 @@ test("welcome note is created on first login", async ({ page, baseURL }) => {
   const items = page.getByTestId("list-pane").getByTestId("note-item");
   await expect(items).toHaveCount(1, { timeout: 5000 });
   await expect(page.getByTestId("content-pane")).toContainText("Greetings");
-  await expect(page.getByTestId("content-pane")).toContainText("Press ? for keyboard shortcuts.");
+  await expect(page.getByTestId("content-pane")).toContainText("Press ⌘/ (Ctrl+/) for keyboard shortcuts.");
+});
+
+test("welcome note opens in read mode, not edit mode (first login)", async ({ page, baseURL }) => {
+  await loadAndSignIn(page, baseURL!);
+  await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(1, { timeout: 5000 });
+  // The seeded welcome note must NOT auto-open in edit mode — it stays in read (idle) mode.
+  await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+  // Read mode shows no editor textbox.
+  await expect(page.getByTestId("content-pane").getByRole("textbox")).toHaveCount(0);
+});
+
+test("⌘/ surfaces shortcuts even after entering edit mode on the welcome note", async ({ page, baseURL }) => {
+  await loadAndSignIn(page, baseURL!);
+  await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(1, { timeout: 5000 });
+  // Reproduce the reported flow: user reflexively presses Enter and lands in edit mode.
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+  // ? would just type a literal "?" here, but ⌘/ still opens the shortcuts overlay.
+  await page.keyboard.press("ControlOrMeta+/");
+  await expect(page.getByTestId("help-overlay")).toBeVisible();
 });
 
 test("welcome note is not re-created on subsequent login", async ({ page, baseURL }) => {

--- a/spec.md
+++ b/spec.md
@@ -104,6 +104,7 @@ SS → 'Esc Esc'              → IS    (message filter cleared)
 | `p`              | IS         | Toggle regular pin on selected note (idle-mode top only)    |
 | `Shift+P`        | IS         | Toggle tag-pin on selected note (search-mode top when first tag matches) |
 | `?`              | IS         | Show keyboard shortcuts help overlay                        |
+| `⌘/` / `Ctrl+/`  | IS/ES/SS   | Show keyboard shortcuts help overlay (works from any state)  |
 | `d` then `d`     | IS         | Open `https://notedude.app/donate` in a new browser tab    |
 | `r` then `r`     | IS         | Open `mailto:issues20260531@notedude.app` to report an issue |
 | `d` then `m`     | IS         | Toggle dark/light mode                                      |
@@ -203,10 +204,10 @@ When a tag filter is active, the List Pane shows only notes whose content contai
 
 ## Help Overlay
 
-Pressing `?` in Idle State shows a full-screen overlay listing all keyboard shortcuts. The overlay:
+Pressing `⌘/` (`Ctrl+/`) from any state — or `?` from Idle State — shows a full-screen overlay listing all keyboard shortcuts. The overlay:
 - Has `data-testid="help-overlay"`
 - Is dismissed by pressing any key or clicking anywhere
-- Is not accessible from Editing or Search state
+- `⌘/` works from Idle, Editing, and Search state (it is a modifier combo, so it is safe while typing — plain `/` still types normally). `?` is only recognized in Idle State, so it cannot be reached once a note is being edited; `⌘/` is the reliable way to surface shortcuts from edit mode.
 
 ## Pinning Indicators
 
@@ -257,7 +258,7 @@ A note `#client-acme Status update...` with `tagPinned = true` will appear first
 - **Pinning**: Pinned notes appear at the top of the List Pane in idle mode. In search/filter mode they behave like regular notes
 - **Tag-pinning**: Tag-pinned notes appear at the top of filtered results when their first tag matches the active search query
 - **Auto-save**: Edits are saved automatically on state transition out of ES
-- **Welcome note**: On first login (Firestore returns zero notes), a welcome note is automatically created with content `"Greetings\nPress ? for keyboard shortcuts."`. It is created only once — subsequent logins with existing notes do not re-create it. The welcome note appears at the top of the note list.
+- **Welcome note**: On first login (Firestore returns zero notes), a welcome note is automatically created with content `"Greetings\nPress ⌘/ (Ctrl+/) for keyboard shortcuts."`. It is created only once — subsequent logins with existing notes do not re-create it. The welcome note appears at the top of the note list and opens in **read (idle) mode**, never edit mode.
 
 ## Persistence & Security
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -393,7 +393,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
         if (!welcomeSeededRef.current && remoteNotes.length === 0) {
           welcomeSeededRef.current = true;
           const now = Date.now();
-          const welcome: Note = { id: crypto.randomUUID(), content: "Greetings\nPress ? for keyboard shortcuts.", pinned: false, tagPinned: false, createdAt: now, updatedAt: now };
+          const welcome: Note = { id: crypto.randomUUID(), content: "Greetings\nPress ⌘/ (Ctrl+/) for keyboard shortcuts.", pinned: false, tagPinned: false, createdAt: now, updatedAt: now };
           saveNote(uid, welcome);
           setNotes([welcome]);
           setSynced(true);
@@ -520,6 +520,13 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
         if (appState === "editing") saveEdits();
         setSelectedId(targetId);
         setAppState("editing");
+        return;
+      }
+      // ⌘/ or Ctrl+/ — show keyboard shortcuts from any state.
+      // Safe while editing: it's a modifier combo, so plain "/" still types normally.
+      if ((e.metaKey || e.ctrlKey) && e.key === "/") {
+        e.preventDefault();
+        setShowHelp(true);
         return;
       }
 
@@ -1048,7 +1055,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
                 ["d → d",   "open donate page"],
                 ["r → r",   "report an issue"],
                 ["l → l",   "log out"],
-                ["?",       "show this"],
+                ["⌘/ or ?", "show this (⌘/ works from any mode)"],
               ]],
             ] as [string, [string, string][]][]).map(([section, rows]) => (
               <div key={section} style={{ marginBottom: 20 }}>


### PR DESCRIPTION
## Problem
A first-time user sees the seeded welcome note "Greetings / Press ? for keyboard shortcuts." Pressing **Enter** (the intended "edit note" shortcut) drops them into edit mode, where:

- `?` no longer opens the help overlay — it just types a literal `?` (correct: `?` must be typeable in notes).
- There's **no on-screen affordance** for getting back to read mode, so the only hint they had ("Press ?") becomes a dead end.

Note: the welcome note does **not** auto-enter edit mode — `appState` stays `idle` after seeding (`App.tsx`). The confusion is users pressing Enter. This PR adds an explicit regression test for that.

## Fix
Add a global **`⌘/` / `Ctrl+/`** handler that opens the shortcuts overlay from **any** state (idle, editing, search). As a modifier combo it's safe to fire while typing — plain `/` still types normally. `?` continues to work in idle for backward compatibility.

## Changes
- `App.tsx`: global `⌘/` handler (placed with the other cross-state handlers); welcome-note hint now reads "Press ⌘/ (Ctrl+/) for keyboard shortcuts."; help overlay lists `⌘/`.
- `spec.md`: document the `⌘/` shortcut and that the welcome note opens in read (idle) mode.

## Tests
- `⌘/` opens help from **idle**, **editing**, and **search** states.
- Plain `/` still types into the editor (no hijack of the slash key).
- Welcome note opens in **read (idle) mode, not edit mode** on first login.
- `⌘/` surfaces shortcuts even after entering edit mode on the welcome note (the reported flow).

### Test run
- Non-emulator suite: **161/161 passed**
- Firebase-roundtrip suite (with emulator): **12/12 passed**

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)