### PR TITLE
Make dark mode the default theme (app + login screen)

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -903,32 +903,46 @@ test.describe("Donate Shortcut", () => {
 });
 
 test.describe("Dark Mode", () => {
-  test("app starts in light mode by default", async ({ page }) => {
+  test("app starts in dark mode by default", async ({ page }) => {
+    await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "dark");
+  });
+
+  test("app has a dark background by default", async ({ page }) => {
+    const bg = await page.getByTestId("app").evaluate((el) =>
+      window.getComputedStyle(el).backgroundColor
+    );
+    expect(bg).not.toBe("rgb(255, 255, 255)");
+  });
+
+  test("pressing 'd' then 'm' toggles to light mode", async ({ page }) => {
+    await page.keyboard.press("d");
+    await page.keyboard.press("m");
     await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "light");
   });
 
-  test("pressing 'd' then 'm' switches to dark mode", async ({ page }) => {
-    await page.keyboard.press("d");
-    await page.keyboard.press("m");
-    await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "dark");
-  });
-
-  test("pressing 'd' then 'm' again toggles back to light mode", async ({ page }) => {
-    await page.keyboard.press("d");
-    await page.keyboard.press("m");
-    await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "dark");
+  test("pressing 'd' then 'm' twice returns to dark mode", async ({ page }) => {
     await page.keyboard.press("d");
     await page.keyboard.press("m");
     await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "light");
-  });
-
-  test("dark mode persists across page reloads via localStorage", async ({ page }) => {
     await page.keyboard.press("d");
     await page.keyboard.press("m");
     await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "dark");
+  });
+
+  test("explicit light preference is respected on load", async ({ page }) => {
+    await page.evaluate(() => localStorage.setItem("theme", "light"));
     await page.reload();
     await page.getByTestId("app").focus();
-    await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "dark");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "light");
+  });
+
+  test("theme preference persists across page reloads via localStorage", async ({ page }) => {
+    await page.keyboard.press("d");
+    await page.keyboard.press("m"); // dark (default) -> light
+    await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "light");
+    await page.reload();
+    await page.getByTestId("app").focus();
+    await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "light");
   });
 
   test("'dm' does not toggle in editing state", async ({ page }) => {
@@ -936,16 +950,7 @@ test.describe("Dark Mode", () => {
     await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
     await page.keyboard.press("d");
     await page.keyboard.press("m");
-    await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "light");
-  });
-
-  test("dark mode applies a dark background to the app", async ({ page }) => {
-    await page.keyboard.press("d");
-    await page.keyboard.press("m");
-    const bg = await page.getByTestId("app").evaluate((el) =>
-      window.getComputedStyle(el).backgroundColor
-    );
-    expect(bg).not.toBe("rgb(255, 255, 255)");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "dark");
   });
 });
 
@@ -1024,7 +1029,7 @@ test.describe("Prefix Key Cancellation", () => {
     await page.waitForTimeout(200);
     expect(newTabs).toHaveLength(0);
     await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
-    await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "light");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-theme", "dark");
   });
 });
 

--- a/e2e/login-theme.spec.ts
+++ b/e2e/login-theme.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+
+const DARK_BG = "rgb(26, 26, 26)"; // #1a1a1a
+const LIGHT_BG = "rgb(255, 255, 255)"; // #ffffff
+
+test.describe("Login screen theme", () => {
+  test("login screen renders dark by default", async ({ page }) => {
+    await page.goto("/");
+    const login = page.getByTestId("login-screen");
+    await expect(login).toBeVisible();
+    const bg = await login.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bg).toBe(DARK_BG);
+  });
+
+  test("login screen respects an explicit light preference", async ({ page }) => {
+    await page.goto("/");
+    await page.evaluate(() => localStorage.setItem("theme", "light"));
+    await page.reload();
+    const login = page.getByTestId("login-screen");
+    await expect(login).toBeVisible();
+    const bg = await login.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bg).toBe(LIGHT_BG);
+  });
+});

--- a/spec.md
+++ b/spec.md
@@ -160,10 +160,13 @@ Pressing `Shift+Y` in Idle State archives the selected note:
 
 ## Dark Mode
 
-- Pressing `d` then `m` in Idle State toggles between dark and light mode
+- **Dark mode is the default** for both the login / pre-app screens and the main app. New users, and any user who has never toggled the theme, see dark mode.
+- Light mode is applied only when the user has explicitly selected it, persisted as `localStorage` key `theme` with the value `"light"`. Absence of a stored preference (or the value `"dark"`) means dark mode.
+- Pressing `d` then `m` in Idle State toggles between dark and light mode and persists the choice
 - Preference persists across sessions via `localStorage` key `theme`
 - The app root element carries `data-theme="dark"` or `data-theme="light"` reflecting the current mode
-- Dark mode inverts the color scheme: dark background, light text, adjusted borders and highlights
+- Dark mode uses a dark background, light text, and adjusted borders and highlights
+- The default dark background is applied globally (via the root layout, before first paint) so the page loads dark with no light flash; the login screen and pre-app screens (loading, demo-mode bar, signed-in bar) follow the same default and respect an explicit light preference
 
 ## Note List Item Display (Apple Notes Style)
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,10 +14,16 @@ export const metadata: Metadata = {
   },
 };
 
+// Dark mode is the default. This runs before first paint and only switches the
+// page background to light when the user has explicitly chosen light mode,
+// preventing a light flash on load.
+const themeScript = `try{document.documentElement.style.backgroundColor=localStorage.getItem('theme')==='light'?'#ffffff':'#1a1a1a';}catch(e){}`;
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" style={{ backgroundColor: "#1a1a1a" }} suppressHydrationWarning>
       <head>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
         <link rel="icon" href="/notedude-n_d-icon-32.png" sizes="32x32" />
         <link rel="icon" href="/notedude-n_d-icon-16.png" sizes="16x16" />
         <link rel="apple-touch-icon" href="/notedude-n_d-icon-180.png" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,10 +17,21 @@ function useIsMobile(): boolean | null {
   return isMobile;
 }
 
+// Dark mode is the default for the pre-app screens too; only switch to light if
+// the user has explicitly chosen it (mirrors the logic in App.tsx).
+function useDarkMode(): boolean {
+  const [darkMode, setDarkMode] = useState(true);
+  useEffect(() => {
+    if (localStorage.getItem("theme") === "light") setDarkMode(false);
+  }, []);
+  return darkMode;
+}
+
 export default function Page() {
   const { user, loading, login, logout } = useAuth();
   const [demoMode, setDemoMode] = useState(false);
   const isMobile = useIsMobile();
+  const darkMode = useDarkMode();
 
   useEffect(() => {
     if (loading || user || demoMode) return;
@@ -32,9 +43,14 @@ export default function Page() {
     return () => window.removeEventListener("keydown", handleKey);
   }, [loading, user, demoMode, login]);
 
+  const bg = darkMode ? "#1a1a1a" : "#ffffff";
+  const fg = darkMode ? "#e8e8e8" : "#000000";
+  const muted = darkMode ? "#888" : "#666";
+  const border = darkMode ? "#444" : "#ccc";
+
   if (SKIP_AUTH) {
     return (
-      <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
+      <div style={{ height: "100vh", display: "flex", flexDirection: "column", background: bg }}>
         <div style={{ flex: 1 }}>
           <App />
         </div>
@@ -43,12 +59,12 @@ export default function Page() {
   }
 
   if (loading || isMobile === null) {
-    return <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", fontFamily: "'Fira Code', monospace" }}>loading...</div>;
+    return <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", fontFamily: "'Fira Code', monospace", background: bg, color: fg }}>loading...</div>;
   }
 
   if (isMobile) {
     return (
-      <div data-testid="mobile-block" style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", fontFamily: "'Fira Code', monospace", padding: 32, textAlign: "center" }}>
+      <div data-testid="mobile-block" style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", fontFamily: "'Fira Code', monospace", padding: 32, textAlign: "center", background: bg, color: fg }}>
         notedude is a keyboard-driven app and does not support mobile browsers.
       </div>
     );
@@ -56,10 +72,10 @@ export default function Page() {
 
   if (demoMode) {
     return (
-      <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
-        <div style={{ display: "flex", justifyContent: "flex-end", padding: "4px 8px", fontSize: 12, fontFamily: "'Fira Code', monospace", color: "#888" }}>
+      <div style={{ height: "100vh", display: "flex", flexDirection: "column", background: bg }}>
+        <div style={{ display: "flex", justifyContent: "flex-end", padding: "4px 8px", fontSize: 12, fontFamily: "'Fira Code', monospace", color: muted }}>
           demo mode —{" "}
-          <button onClick={() => setDemoMode(false)} style={{ marginLeft: 6, fontFamily: "inherit", fontSize: "inherit", cursor: "pointer", background: "none", border: "none", textDecoration: "underline", color: "#888" }}>
+          <button onClick={() => setDemoMode(false)} style={{ marginLeft: 6, fontFamily: "inherit", fontSize: "inherit", cursor: "pointer", background: "none", border: "none", textDecoration: "underline", color: muted }}>
             sign in
           </button>
         </div>
@@ -72,12 +88,12 @@ export default function Page() {
 
   if (!user) {
     return (
-      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", height: "100vh", fontFamily: "'Fira Code', monospace", gap: 16 }}>
+      <div data-testid="login-screen" style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", height: "100vh", fontFamily: "'Fira Code', monospace", gap: 16, background: bg, color: fg }}>
         <div>notedude</div>
         <button onClick={login} style={{ padding: "8px 16px", fontFamily: "inherit", fontSize: 14, cursor: "pointer" }}>
           ⏎ sign in with google
         </button>
-        <button onClick={() => setDemoMode(true)} style={{ padding: "8px 16px", fontFamily: "inherit", fontSize: 14, cursor: "pointer", background: "none", border: "1px solid #ccc", color: "#666" }}>
+        <button onClick={() => setDemoMode(true)} style={{ padding: "8px 16px", fontFamily: "inherit", fontSize: 14, cursor: "pointer", background: "none", border: `1px solid ${border}`, color: muted }}>
           <u>d</u>emo mode
         </button>
       </div>
@@ -85,9 +101,9 @@ export default function Page() {
   }
 
   return (
-    <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
-      <div style={{ display: "flex", justifyContent: "flex-end", padding: "4px 8px", fontSize: 12, fontFamily: "'Fira Code', monospace", color: "#666" }}>
-        {user.email} <button onClick={logout} style={{ marginLeft: 8, fontFamily: "inherit", fontSize: "inherit", cursor: "pointer", background: "none", border: "none", textDecoration: "underline", color: "#666" }}>logout</button>
+    <div style={{ height: "100vh", display: "flex", flexDirection: "column", background: bg }}>
+      <div style={{ display: "flex", justifyContent: "flex-end", padding: "4px 8px", fontSize: 12, fontFamily: "'Fira Code', monospace", color: muted }}>
+        {user.email} <button onClick={logout} style={{ marginLeft: 8, fontFamily: "inherit", fontSize: "inherit", cursor: "pointer", background: "none", border: "none", textDecoration: "underline", color: muted }}>logout</button>
       </div>
       <div style={{ flex: 1 }}>
         <App uid={user.uid} onLogout={logout} />

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -154,14 +154,15 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
   const [editorTagDismissed, setEditorTagDismissed] = useState(false);
   const [editorCursorPos, setEditorCursorPos] = useState(0);
   const [editorDropdownPos, setEditorDropdownPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
-  const [darkMode, setDarkMode] = useState(false);
+  const [darkMode, setDarkMode] = useState(true);
   const [showHelp, setShowHelp] = useState(false);
   const [saveFlashId, setSaveFlashId] = useState<string | null>(null);
   const [showTaskMove, setShowTaskMove] = useState(false);
   const [taskMoveIndex, setTaskMoveIndex] = useState(0);
   const [recentSearchTags, setRecentSearchTags] = useState<string[]>([]);
   useEffect(() => {
-    if (localStorage.getItem("theme") === "dark") setDarkMode(true);
+    // Dark mode is the default; only switch to light if the user explicitly chose it.
+    if (localStorage.getItem("theme") === "light") setDarkMode(false);
     try {
       const stored = localStorage.getItem("recentSearchTags");
       if (stored) setRecentSearchTags(JSON.parse(stored));


### PR DESCRIPTION
## Summary
Makes **dark mode the default** for both the main app and the login / pre-app screens. Light mode is now applied only when the user has explicitly selected it (persisted as `localStorage.theme === "light"`); the `d → m` toggle still flips and persists the choice.

Closes #88

## Changes
- **`src/components/App.tsx`** — default `darkMode` state to `true`; the init effect now switches to light only when `theme === "light"` (absence of a stored preference, or `"dark"`, means dark). Defaulting the initial state to dark also avoids a light flash before the effect runs.
- **`src/app/page.tsx`** — the pre-app screens (login, loading, mobile-block, demo-mode bar, signed-in bar) had no theme awareness and rendered on white. They now follow the same default-dark rule via a small `useDarkMode` hook and respect an explicit light preference. Added `data-testid="login-screen"` for testing.
- **`src/app/layout.tsx`** — default the page background to dark and add a tiny pre-paint script that flips it to light only for light-preference users, so the page loads dark with no flash. `suppressHydrationWarning` avoids the expected script/SSR mismatch warning.
- **`spec.md`** — documents dark mode as the default.

## Tests
- Updated the **Dark Mode** suite in `e2e/app.spec.ts` for the new default (starts dark; `d → m` toggles to light; explicit light preference respected; persistence).
- New `e2e/login-theme.spec.ts` — login screen renders dark by default and respects an explicit light preference.
- Full Chromium suite: **160 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)