### PR TITLE
Compose in search context: inherit filter tags, never evict the edited note

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1795,11 +1795,12 @@ test.describe("List stability while editing (#93, #94)", () => {
     await page.keyboard.press("c");
     await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
 
-    // The editor holds the brand-new empty note — not the first filtered note
+    // The editor holds the brand-new note — not the first filtered note. Under a tag
+    // filter the new note is seeded with that tag, caret before it (#99).
     const editor = page.getByTestId("content-pane").getByRole("textbox");
-    await expect(editor).toHaveValue("");
+    await expect(editor).toHaveValue(" #guide");
     await page.keyboard.type("fresh note body");
-    await expect(editor).toHaveValue("fresh note body");
+    await expect(editor).toHaveValue("fresh note body #guide");
 
     // The pre-existing note is untouched
     await page.keyboard.press("Escape");
@@ -2004,5 +2005,201 @@ test.describe("Content pane does not shift between read and edit (#91)", () => {
 
     expect(after.x).toBeCloseTo(idle.x, 1);
     expect(after.y).toBeCloseTo(idle.y, 1);
+test.describe("Compose in search context (#93, #99, #100, #101)", () => {
+  const editorOf = (page: import("@playwright/test").Page) =>
+    page.getByTestId("content-pane").getByRole("textbox");
+  const selectedItem = (page: import("@playwright/test").Page) =>
+    page.getByTestId("list-pane").locator("[data-selected='true']");
+
+  // Apply a filter and land back in idle state
+  async function applyFilter(page: import("@playwright/test").Page, query: string) {
+    await page.keyboard.press("/");
+    await page.getByTestId("top-pane").getByRole("searchbox").fill(query);
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+  }
+
+  test("'c' under a tag filter seeds the note with that tag", async ({ page }) => {
+    await applyFilter(page, "#guide");
+    await page.keyboard.press("c");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+
+    await expect(editorOf(page)).toHaveValue(" #guide");
+  });
+
+  test("'c' under a tag filter leaves the cursor before the tag", async ({ page }) => {
+    await applyFilter(page, "#guide");
+    await page.keyboard.press("c");
+    await expect(editorOf(page)).toHaveValue(" #guide");
+
+    await page.keyboard.type("Ship it");
+    await expect(editorOf(page)).toHaveValue("Ship it #guide");
+  });
+
+  test("'c' under a tag filter does not hijack an existing note (#93)", async ({ page }) => {
+    await applyFilter(page, "#guide");
+    const before = await page.getByTestId("note-item-title").allInnerTexts();
+    expect(before).toHaveLength(2);
+
+    // Move selection off the first result — the old bug snapped back to it
+    await page.keyboard.press("j");
+    await page.keyboard.press("c");
+    await page.keyboard.type("Brand new");
+    await expect(editorOf(page)).toHaveValue("Brand new #guide");
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+
+    // Both original notes survive untouched, plus the new one
+    const after = await page.getByTestId("note-item-title").allInnerTexts();
+    expect(after).toContain("Keyboard shortcuts #guide");
+    expect(after).toContain("Getting started #intro #guide");
+    expect(after).toContain("Brand new #guide");
+  });
+
+  test("the seeded note stays selected and visible in the filtered list", async ({ page }) => {
+    await applyFilter(page, "#guide");
+    await page.keyboard.press("c");
+    await expect(selectedItem(page).getByTestId("note-item-title")).toHaveText("New Note");
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(3);
+  });
+
+  test("a tag-only new note shows the 'New Note' / 'No Content' placeholders", async ({ page }) => {
+    await applyFilter(page, "#guide");
+    await page.keyboard.press("c");
+    await expect(selectedItem(page).getByTestId("note-item-title")).toHaveText("New Note");
+    await expect(selectedItem(page).getByTestId("note-item-meta")).toContainText("No Content");
+  });
+
+  test("'c' seeds every tag in a multi-tag filter", async ({ page }) => {
+    await applyFilter(page, "#intro #guide");
+    await page.keyboard.press("c");
+    await expect(editorOf(page)).toHaveValue(" #intro #guide");
+  });
+
+  test("'c' does not seed free-text terms in the filter", async ({ page }) => {
+    await applyFilter(page, "#guide shortcuts");
+    await page.keyboard.press("c");
+    await expect(editorOf(page)).toHaveValue(" #guide");
+  });
+
+  test("'c' never seeds #archived", async ({ page }) => {
+    // Archive a note so #archived exists, then filter by it
+    await page.keyboard.press("Shift+Y");
+    await applyFilter(page, "#archived");
+    await page.keyboard.press("c");
+    await expect(editorOf(page)).toHaveValue("");
+  });
+
+  test("a tag-only note is discarded when editing exits", async ({ page }) => {
+    await applyFilter(page, "#guide");
+    const before = await page.getByTestId("list-pane").getByTestId("note-item").count();
+
+    await page.keyboard.press("c");
+    await expect(editorOf(page)).toHaveValue(" #guide");
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(before);
+
+    // ...and it is not lurking outside the filter either
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("Escape");
+    const titles = await page.getByTestId("note-item-title").allInnerTexts();
+    expect(titles).not.toContain("New Note");
+  });
+
+  test("'c' under a free-text filter keeps the new note visible while editing", async ({ page }) => {
+    await applyFilter(page, "Tips");
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(1);
+
+    await page.keyboard.press("c");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+    await expect(editorOf(page)).toHaveValue("");
+    // The blank note cannot match "Tips" but must not vanish out from under the editor
+    await expect(selectedItem(page).getByTestId("note-item-title")).toHaveText("New Note");
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(2);
+
+    await page.keyboard.type("Unrelated thought");
+    await expect(editorOf(page)).toHaveValue("Unrelated thought");
+    await expect(selectedItem(page).getByTestId("note-item-title")).toHaveText("Unrelated thought");
+  });
+
+  test("'c' under a filter matching nothing still shows the new note", async ({ page }) => {
+    await applyFilter(page, "zzzznomatch");
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(0);
+
+    await page.keyboard.press("c");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(1);
+    await expect(selectedItem(page).getByTestId("note-item-title")).toHaveText("New Note");
+  });
+
+  test("a note being edited is not evicted when it stops matching the filter", async ({ page }) => {
+    await applyFilter(page, "#tips");
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(1);
+
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+    await editorOf(page).fill("Tips\nUse 'j' and 'k' to navigate.");
+
+    // Tag removed — the note no longer matches, but the editor must stay on it
+    await expect(editorOf(page)).toHaveValue("Tips\nUse 'j' and 'k' to navigate.");
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(1);
+    await expect(selectedItem(page).getByTestId("note-item-title")).toHaveText("Tips");
+  });
+
+  test("Shift+C clears the filter and creates a blank note (#100)", async ({ page }) => {
+    await applyFilter(page, "#guide");
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(2);
+
+    await page.keyboard.press("Shift+C");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+    await expect(editorOf(page)).toHaveValue("");
+    await expect(page.getByTestId("top-pane").getByRole("searchbox")).toHaveValue("");
+    // Filter gone: the full list is back, plus the new note
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(8);
+  });
+
+  test("Shift+C from an unfiltered list behaves like 'c'", async ({ page }) => {
+    await page.keyboard.press("Shift+C");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+    await expect(editorOf(page)).toHaveValue("");
+    await expect(selectedItem(page).getByTestId("note-item-title")).toHaveText("New Note");
+  });
+
+  test("Shift+C is listed in the help overlay", async ({ page }) => {
+    await page.keyboard.press("?");
+    await expect(page.getByTestId("help-overlay")).toBeVisible();
+    await expect(page.getByTestId("help-overlay")).toContainText("Shift+C");
+  });
+
+  test("clicking a tag leaves that tag in the search box (#101)", async ({ page }) => {
+    await page.keyboard.press("/");
+    const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
+    await searchInput.fill("#");
+
+    await page.getByTestId("tag-item").filter({ hasText: "#intro" }).click();
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+    await expect(searchInput).toHaveValue("#intro");
+  });
+
+  test("'c' inherits a filter applied by clicking a tag", async ({ page }) => {
+    await page.keyboard.press("/");
+    await page.getByTestId("top-pane").getByRole("searchbox").fill("#");
+    await page.getByTestId("tag-item").filter({ hasText: "#intro" }).click();
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+
+    await page.getByTestId("app").focus();
+    await page.keyboard.press("c");
+    await expect(editorOf(page)).toHaveValue(" #intro");
+  });
+
+  test("'c' inherits a filter applied by a 't' task shortcut", async ({ page }) => {
+    await page.keyboard.press("t");
+    await page.keyboard.press("t");
+    await page.keyboard.press("c");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+    await expect(editorOf(page)).toHaveValue(" #tasks-today");
   });
 });

--- a/e2e/firebase-roundtrip.spec.ts
+++ b/e2e/firebase-roundtrip.spec.ts
@@ -5,16 +5,26 @@ const AUTH_EMULATOR = "http://127.0.0.1:9099";
 const TEST_EMAIL = "test@notedude.test";
 const TEST_PASSWORD = "password123";
 
-async function createTestUser() {
-  const res = await fetch(
-    `${AUTH_EMULATOR}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=fake-api-key`,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD, returnSecureToken: true }),
-    }
-  );
-  if (!res.ok) throw new Error(`Failed to create test user: ${res.status}`);
+// The auth emulator's bulk account delete in clearEmulatorData() is not synchronous with
+// respect to a following signUp, so the re-create can race it and come back EMAIL_EXISTS.
+// That is a success for our purposes — same credentials, and the uid's Firestore data has
+// already been cleared, so the test still starts from a clean slate (#103).
+async function createTestUser(retries = 10) {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    const res = await fetch(
+      `${AUTH_EMULATOR}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=fake-api-key`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD, returnSecureToken: true }),
+      }
+    );
+    if (res.ok) return;
+    const body = await res.json().catch(() => null);
+    if (body?.error?.message === "EMAIL_EXISTS") return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`Failed to create test user after ${retries} attempts`);
 }
 
 async function signInViaPage(page: Page) {
@@ -241,4 +251,66 @@ test("pinning does not clobber a concurrent content edit (lost-update regression
 
   await ctxA.close();
   await ctxB.close();
+});
+
+test("an untouched new note is never written to Firestore (#77)", async ({ page, baseURL }) => {
+  await loadAndSignIn(page, baseURL!);
+  // Wait for the seeded welcome note before touching anything
+  await expect(page.getByTestId("note-item-title").filter({ hasText: "Greetings" }).first()).toBeVisible();
+
+  // Create a note and leave it immediately, without typing anything
+  await page.keyboard.press("c");
+  await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+  await expect(page.getByTestId("note-item-title").filter({ hasText: "New Note" })).toHaveCount(0);
+
+  // Give any (incorrectly) queued debounced write time to land, then reload.
+  // Before the fix, `c` wrote an empty document straight away and it came back here.
+  await page.waitForTimeout(900);
+  await page.reload();
+  await signInViaPage(page);
+  await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle", { timeout: 10000 });
+  // Wait for sync to actually land (a positive signal) before asserting the absence of a ghost
+  await expect(page.getByTestId("note-item-title").filter({ hasText: "Greetings" }).first())
+    .toBeVisible({ timeout: 15000 });
+  // A persisted empty note comes back as "No Text Entered" (isNew is not persisted).
+  // Asserted by title rather than by total count, which is hostage to the unrelated
+  // welcome-note seeding race (#78).
+  await expect(page.getByTestId("note-item-title").filter({ hasText: "No Text Entered" })).toHaveCount(0);
+  await expect(page.getByTestId("note-item-title").filter({ hasText: "New Note" })).toHaveCount(0);
+});
+
+test("an untouched tag-seeded note is never written to Firestore (#99)", async ({ page, baseURL }) => {
+  await loadAndSignIn(page, baseURL!);
+  // Wait for the welcome note to settle before adding to it
+  await expect(page.getByTestId("note-item-title").filter({ hasText: "Greetings" }).first()).toBeVisible();
+
+  // Give ourselves a tag to filter by
+  await page.keyboard.press("c");
+  await page.getByTestId("content-pane").getByRole("textbox").fill("Alpha #work");
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("note-item-title").filter({ hasText: "Alpha #work" }).first()).toBeVisible();
+
+  // Filter by it, compose (inheriting #work), then bail out without typing
+  await page.keyboard.press("/");
+  await page.getByTestId("top-pane").getByRole("searchbox").fill("#work");
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+  await page.keyboard.press("c");
+  await expect(page.getByTestId("content-pane").getByRole("textbox")).toHaveValue(" #work");
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+
+  await page.waitForTimeout(900);
+  await page.reload();
+  await signInViaPage(page);
+  await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle", { timeout: 10000 });
+  // Wait for sync to actually land (a positive signal) before asserting the absence of a ghost
+  await expect(page.getByTestId("note-item-title").filter({ hasText: "Alpha #work" }).first())
+    .toBeVisible({ timeout: 15000 });
+  // A persisted tag-only note would come back titled exactly "#work". Asserted by title
+  // rather than by total count, which is hostage to the welcome-note seeding race (#78).
+  await expect(page.getByTestId("note-item-title").filter({ hasText: /^\s*#work\s*$/ })).toHaveCount(0);
+  await expect(page.getByTestId("note-item-title").filter({ hasText: "New Note" })).toHaveCount(0);
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,9 @@ const useEmulator = process.env.FIREBASE_ROUNDTRIP === "true";
 export default defineConfig({
   testDir: "./e2e",
   timeout: 15000,
+  // Emulator runs must be serial: every beforeEach wipes the single shared emulator, so
+  // parallel workers clear each other's accounts and notes mid-test (#103).
+  workers: useEmulator ? 1 : undefined,
   globalSetup: useEmulator ? "./e2e/emulator-setup.ts" : undefined,
   use: {
     baseURL: useEmulator ? "http://localhost:3001" : "http://localhost:3000",

--- a/spec.md
+++ b/spec.md
@@ -73,7 +73,8 @@ The app consists of three panes:
 ```
 App Start → IS
 
-IS → 'c'                    → ES    (new note created, content blank, title "New Note")
+IS → 'c'                    → ES    (new note created, inheriting the active filter's tags)
+IS → 'Shift+C'              → ES    (filter cleared, new blank note created)
 IS → 'Enter'                → ES    (selected note becomes editable, cursor at end)
 IS → click content pane     → ES    (selected note becomes editable)
 IS → '/'                    → SS    (search bar focused)
@@ -91,7 +92,8 @@ SS → 'Esc Esc'              → IS    (message filter cleared)
 
 | Shortcut         | From State | Action                                      |
 |------------------|------------|---------------------------------------------|
-| `c`              | IS         | Create new blank note, enter editing state  |
+| `c`              | IS         | Create new note inheriting the active filter's tags, enter editing state |
+| `Shift+C`        | IS         | Clear the active filter, create a new blank note, enter editing state    |
 | `Enter`          | IS         | Edit selected note, cursor at end of content|
 | `/`              | IS         | Focus search bar, enter search state        |
 | `j` / `↓`        | IS         | Select next note in list                    |
@@ -185,9 +187,56 @@ Each note in the List Pane displays two lines:
 Each item carries `data-testid="note-item"` plus state attributes: `data-selected`, `data-pinned`, `data-tagpinned`, `data-flash`, and `data-archived`.
 
 ### Display rules
-- **New note** (created via `c`, content is blank): Title = `"New Note"`, metadata = `<timestamp> No Content`, Content Pane is empty
+- **New note** (created via `c` / `Shift+C`, holding no text beyond any inherited tags): Title = `"New Note"`, metadata = `<timestamp> No Content`. A note seeded with the active filter's tags counts as new until the user types — the tags show in the Content Pane but not in the list placeholders
 - **Note with content**: Title = first line of content, metadata = `<timestamp> <abbreviated first line>`
 - **Note with all content deleted** (while editing): Title = `"No Text Entered"`, metadata = `<timestamp> No Content`. A note left empty when editing exits is **discarded** (removed from the list) rather than kept — see Behaviors.
+
+## Composing a Note
+
+A search is a **context**, not just a view: in notedude tags are the folder system, so a note composed while a filter is active belongs to that filter by default.
+
+### `c` — compose in context
+
+Creates a new note that inherits the `#tags` of the active filter and enters Editing State. The filter stays applied.
+
+- The note's content is seeded with a leading space followed by the inherited tags, and the **caret is placed at position 0**, so typing a title yields the house convention `Title #tag`:
+
+  ```
+  filter: #tasks-today   →  c  →  editor: "▮ #tasks-today"
+                               type "Call the vet"
+                               →  "Call the vet #tasks-today"
+  ```
+- Tags are de-duplicated and lower-cased. **Free-text terms in the query are not seeded** — the app cannot know whether they belong in the title or the body.
+- **`#archived` is never inherited**, since that would archive the note before a character is typed.
+- Because the seeded note genuinely matches the filter, it appears at the top of the list the user is already looking at.
+- With no active filter, `c` creates a blank note as before.
+
+### `Shift+C` — compose clean
+
+Clears the active filter and the search query, then creates a new **blank** note (no inherited tags) and enters Editing State. This is the escape hatch for "the note I want isn't part of what I'm looking at".
+
+### The note being edited is never filtered out
+
+While in Editing State, the note under the editor is **always present in the List Pane**, regardless of whether it matches the active filter. If it does not match, it is shown at the top of the list.
+
+This holds for a new note under a free-text filter (which it can never match), a filter that matches nothing at all, and an existing note whose matching tag is deleted mid-edit. Without this guarantee the note is evicted from the list and the editor silently retargets whichever note takes its place (#93).
+
+The mechanism is the editing freeze described under **Stable list while editing** in Behaviors: list membership and order are captured on entry to Editing State, and the note under the editor is prepended if it was not in that snapshot. Freezing the order too is what stops the `updatedAt` bump from every keystroke re-sorting search results mid-edit (#94).
+
+When editing exits, a note that no longer matches drops out of the filtered list normally; the save flash on the row is the user's confirmation that it was saved rather than lost.
+
+### Discarding an untouched note
+
+Extending the empty-note rule: when editing exits, the note is discarded if either
+
+- its content is blank (any note), **or**
+- it is still untouched (`isNew`) and contains nothing but tags — i.e. stripping every `#tag` leaves no text.
+
+The second clause means `c` followed immediately by `Esc` leaves no junk tag-only note behind. A tag-only note also shows the `"New Note"` / `"No Content"` placeholders in the List Pane, exactly as a blank one does.
+
+### No write before first keystroke
+
+A newly created note is **not** written to Firestore on creation — only once the user types content (`#77`). A discarded note also cancels any queued write, so it can never be resurrected by a pending flush.
 
 ## Tags
 
@@ -208,6 +257,7 @@ When the user types `#` as the first character in the search bar:
 5. Arrow Up/Down keys navigate the tag list, highlighting the selected tag (`data-selected="true"`)
 6. Pressing Enter when a tag is highlighted applies it directly as a filter — same as clicking
 7. Clicking a tag applies it directly as a filter — only notes containing that tag are shown in the List Pane
+8. However a filter is applied — typing + `Enter`, clicking a tag, or a `t →` shortcut — the query **remains visible in the search box**. An applied filter is never invisible, so the user can always see why the list is narrowed and what `c` will inherit
 6. The tag dropdown disappears when:
    - A tag is selected
    - The `#` is removed from the search bar
@@ -264,9 +314,10 @@ A note `#client-acme Status update...` with `tagPinned = true` will appear first
 ## Behaviors
 
 - **Note selection**: In IS, the selected note's content is displayed in the Content Pane
-- **New note**: Created with blank content; Content Pane starts empty for fresh typing
+- **New note**: Created blank, or seeded with the active filter's tags — see **Composing a Note**
 - **Click to edit**: In IS, clicking anywhere in the Content Pane enters Editing State for the selected note (clicking a link in the content opens the link instead)
-- **Discard empty note**: When editing exits and the note's content is empty, the note is discarded (removed from the list) rather than kept as a blank entry
+- **Discard empty note**: When editing exits and the note holds no text the user wrote — blank, or untouched and tag-only — the note is discarded (removed from the list) rather than kept as a blank entry
+- **Editing beats filtering**: The note being edited is always shown in the List Pane, even when it does not match the active filter — see **Composing a Note**
 - **Filter**: When a message filter is active, only matching notes appear in the List Pane. Filtering is incremental — the note list updates live as the user types in the search bar
 - **Empty filter results**: When the active filter matches no notes, the List Pane is empty **and the Content Pane is blank**. The previously selected note is deselected rather than left on screen, which would misrepresent a zero-result search as a hit. See #97
 - **Stable list while editing**: Entering Editing State freezes the List Pane's membership and order until editing ends. While editing:
@@ -296,7 +347,7 @@ Notes live at `users/{userId}/notes/{noteId}`.
 - Writes that include unknown fields or oversized content are rejected with `permission-denied`.
 
 ### Write semantics (avoiding lost updates)
-- A note's **content** is written with a full-document `setDoc` (create and content-edit).
+- A note's **content** is written with a full-document `setDoc` (create and content-edit). No write is issued when the note is created — only once the user types (see **Composing a Note**).
 - **Metadata-only toggles** — `pinned` (`p`) and `tagPinned` (`Shift+P`) — are written with a **field-level `updateDoc`** that touches only the toggled field and `updatedAt`. They must **not** rewrite `content`. This prevents a stale in-memory snapshot in one tab/device from overwriting a concurrent content edit made elsewhere (lost update). See #74.
 
 ### Authentication bypass guard

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -25,15 +25,29 @@ const INITIAL_NOTES: Note[] = [
   { id: "7", content: "Ideas #ideas\nCapture them here.", pinned: false, tagPinned: false, createdAt: 7, updatedAt: 7 },
 ];
 
+// What is left of a note once every #tag is stripped out. A note with nothing left holds
+// no text the user actually wrote — only tags it inherited from the active filter.
+function contentWithoutTags(content: string): string {
+  return content.replace(/#[\w-]+/g, "").trim();
+}
+
+// Tags a new note inherits from the active filter. #archived is excluded — inheriting it
+// would archive the note before a single character is typed.
+const NON_INHERITABLE_TAGS = new Set(["#archived"]);
+function inheritedTags(query: string): string[] {
+  const tags = (query.match(/#[\w-]+/g) ?? []).map((t) => t.toLowerCase());
+  return Array.from(new Set(tags)).filter((t) => !NON_INHERITABLE_TAGS.has(t));
+}
+
 function getNoteTitle(note: Note): string {
-  if (note.isNew && note.content === "") return "New Note";
+  if (note.isNew && contentWithoutTags(note.content) === "") return "New Note";
   const firstLine = note.content.split("\n")[0];
   return firstLine || "No Text Entered";
 }
 
 function getNoteMetaSnippet(note: Note): string {
   const lines = note.content.split("\n");
-  if (!lines[0]) return "No Content";
+  if (!lines[0] || contentWithoutTags(note.content) === "") return "No Content";
   const secondLine = lines.slice(1).find((l) => l.trim() !== "") ?? "";
   return secondLine.length > 30 ? secondLine.slice(0, 30) + "…" : secondLine;
 }
@@ -195,6 +209,11 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
   const rPrefixTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const welcomeSeededRef = useRef(false);
   const editingNoteIdRef = useRef<string | null>(null);
+  // Where to put the caret the next time the editor opens; null means "end of content".
+  const newNoteCursorRef = useRef<number | null>(null);
+  // Always-current view of `notes`, for callbacks that must not read a stale array.
+  const notesRef = useRef(notes);
+  notesRef.current = notes;
   // Navigation history: list of note IDs visited (in editing or idle selection)
   const navHistoryRef = useRef<string[]>([]);
   const navIdxRef = useRef(-1); // points to current position in navHistoryRef
@@ -220,6 +239,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
     return { circle: note.pinned, hash: note.tagPinned };
   }
 
+  // The note under the editor, if any. It is exempt from filtering below.
   const editingId = appState === "editing" ? selectedId : null;
 
   const { displayed, displayedArchived } = (() => {
@@ -316,7 +336,9 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
   const selectTag = useCallback((tag: string) => {
     recordSearchTag(tag);
     setActiveFilter(tag);
-    setFilterQuery("");
+    // Leave the tag in the search box, like Enter and the 't' shortcuts do — an applied
+    // filter the user cannot see is a filter they cannot reason about (#101).
+    setFilterQuery(tag);
     setSelectedTagIndex(-1);
     setAppState("idle");
   }, [recordSearchTag]);
@@ -391,16 +413,45 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
     setAppState("editing");
   }, []);
 
+  // Create a note carrying `tags`, and open it for editing with the cursor before them,
+  // so the user types the title and lands on "Title #tag" — the house convention.
+  // Deliberately not saved here: an untouched note must never reach Firestore (#77).
+  const createNote = useCallback((tags: string[]) => {
+    const now = Date.now();
+    const newNote: Note = {
+      id: crypto.randomUUID(),
+      content: tags.length > 0 ? " " + tags.join(" ") : "",
+      pinned: false,
+      tagPinned: false,
+      createdAt: now,
+      updatedAt: now,
+      isNew: true,
+    };
+    newNoteCursorRef.current = 0;
+    setNotes((prev) => [newNote, ...prev]);
+    enterEditing(newNote.id);
+  }, [enterEditing]);
+
   const saveEdits = useCallback(() => {
     editingNoteIdRef.current = null;
-    setNotes((prev) => {
-      const note = prev.find((n) => n.id === selectedId);
-      // Discard note if it's still empty when exiting editing
-      if (note && note.content.trim() === "") {
-        return prev.filter((n) => n.id !== selectedId);
-      }
-      return prev.map((n) => n.id === selectedId && n.isNew ? { ...n, isNew: false } : n);
-    });
+    // Read through the ref, never the closure: a keystroke and the Escape that follows it
+    // can land before this callback is rebuilt, and a stale `notes` here would see the
+    // note as still empty and discard content the user actually typed.
+    const note = notesRef.current.find((n) => n.id === selectedId);
+    // Discard a note that holds nothing the user wrote — blank, or (for a note never yet
+    // touched) only the tags it inherited from the filter, so 'c' then Esc leaves no junk.
+    const isDiscardable = !!note && (
+      note.content.trim() === "" ||
+      (!!note.isNew && contentWithoutTags(note.content) === "")
+    );
+    if (isDiscardable) {
+      // Drop any queued write too, so a discarded note is never resurrected by a flush (#77).
+      if (pendingNoteRef.current?.id === selectedId) pendingNoteRef.current = null;
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      setNotes((prev) => prev.filter((n) => n.id !== selectedId));
+    } else {
+      setNotes((prev) => prev.map((n) => n.id === selectedId && n.isNew ? { ...n, isNew: false } : n));
+    }
     flushSave();
     setAppState("idle");
     if (selectedId) {
@@ -530,8 +581,10 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
     if (appState === "editing" && editorRef.current) {
       const el = editorRef.current;
       el.focus();
-      el.selectionStart = el.value.length;
-      el.selectionEnd = el.value.length;
+      const caret = newNoteCursorRef.current ?? el.value.length;
+      newNoteCursorRef.current = null;
+      el.selectionStart = caret;
+      el.selectionEnd = caret;
     } else if (appState === "search" && searchRef.current) {
       searchRef.current.focus();
     } else if (appState === "idle") {
@@ -601,20 +654,19 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
           }
           return;
         }
-        if (e.key === "c") {
+        // 'c' composes in context: the new note inherits the active filter's tags, so it
+        // belongs to the list you are looking at and stays visible there (#99).
+        if (e.key === "c" && !e.shiftKey) {
           e.preventDefault();
-          const newNote: Note = {
-            id: crypto.randomUUID(),
-            content: "",
-            pinned: false,
-            tagPinned: false,
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
-            isNew: true,
-          };
-          setNotes((prev) => [newNote, ...prev]);
-          debouncedSave(newNote);
-          enterEditing(newNote.id);
+          createNote(inheritedTags(activeFilter));
+          return;
+        }
+        // Shift+C composes clean: drop the filter, start a blank note (#100).
+        if (e.key === "C" && e.shiftKey) {
+          e.preventDefault();
+          setActiveFilter("");
+          setFilterQuery("");
+          createNote([]);
           return;
         }
         if (e.key === "Enter" || e.key === "e") {
@@ -852,7 +904,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [appState, selectedId, filterQuery, displayed, navigable, enterEditing, saveEdits, demo, notes]);
+  }, [appState, selectedId, filterQuery, activeFilter, displayed, navigable, enterEditing, createNote, saveEdits, demo, notes]);
 
   const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
     const html = e.clipboardData.getData("text/html");
@@ -1083,7 +1135,8 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
                 ["k / ↑",   "previous note"],
                 ["1 – 9",   "jump to note by position"],
                 ["⌘[ / ⌘]", "navigate back / forward in history"],
-                ["c",       "create new note"],
+                ["c",       "create new note (inherits tags from the active search)"],
+                ["Shift+C", "create new note, clearing the active search"],
                 ["⏎ / e",   "edit selected note"],
                 ["Esc / ⌘⏎", "save and exit editing"],
               ]],


### PR DESCRIPTION
Closes #93, closes #99, closes #100, closes #101, closes #103. Contributes to #77.

## The bug

Pressing `c` with a search filter active created a **blank** note. A blank note cannot match the query, so the "keep selection in sync with the displayed list" effect evicted it and snapped selection to the first search result — while `appState` was already `editing`. Verified against the running app before touching anything:

```
SELECTED BEFORE c: "Getting started #intro #guide"
STATE AFTER c:     editing
SELECTED AFTER c:  "Keyboard shortcuts #guide"      ← jumped to result #1
EDITOR CONTENTS:   "Keyboard shortcuts #guide\nEnter to edit, Esc to save."
AFTER TYPING:      "...Esc to save.HELLO-NEW-NOTE"  ← appended to the existing note
```

You end up editing someone else's note, and the orphaned blank note had already been written to Firestore.

Second failure mode: with a filter matching **nothing**, the eviction never fires, so you get `data-state="editing"` over an empty list — typing into a note that appears nowhere.

## The design

A search is a **context**, not just a view. In notedude tags *are* the folder system (`t → t` opens your today-list), so a note composed under a filter belongs to it.

| Key | Meaning |
|-----|---------|
| `c` | compose *in context* — inherits the active filter's tags |
| `Shift+C` | compose *clean* — clears the filter, blank note |

```
filter: #tasks-today   →  c  →  editor: "▮ #tasks-today"
                             type "Call the vet"
                             →  "Call the vet #tasks-today"
```

Caret sits before the tags, so you type the title and land on `Title #tag` — the convention the seeded notes already use. Free-text query terms are not seeded (we can't know if they belong in the title or body). `#archived` is never inherited, or `c` would create pre-archived notes.

**The generic fix** is separate from the seeding: the note being edited is never dropped from the list, whatever the filter says. That covers free-text queries, zero-result queries, and deleting a matching tag mid-edit.

## Also fixed

- **Discard rule extended** — an untouched note holding only inherited tags is discarded on exit, so `c` then `Esc` leaves no junk.
- **No write before first keystroke** (#77) — `c` used to `debouncedSave` an empty note immediately. Discarding now also cancels any queued write.
- **Invisible filter** (#101) — clicking a tag in the dropdown set `activeFilter` but cleared `filterQuery`, leaving the list filtered with an empty search box. `c` must not inherit from a filter the user cannot see.
- **Stale-closure guard** — `saveEdits` reads `notes` through a ref. A keystroke and the `Escape` after it can land before the callback is rebuilt; a stale array would see the note as empty and **discard content the user actually typed**. Caught by the roundtrip suite while building this.

## Test harness (#103)

The emulator project ran in **parallel workers against one shared emulator**, so every `beforeEach`'s `clearEmulatorData()` wiped other workers' accounts and notes mid-test. Pinned to `workers: 1`, and made `createTestUser()` idempotent as defence in depth.

Measured on the same machine, `-g "cross-session sync" --repeat-each=4`: **4/4 failing → 4/4 passing**.

## Testing

Tests written before the implementation (18 new in `app.spec.ts`, 2 new roundtrip tests), confirmed red first — all 18 failed against the old code.

- `npx playwright test` — **178/178 pass**
- `FIREBASE_ROUNDTRIP=true npx playwright test e2e/firebase-roundtrip.spec.ts` — 12/12, and the two new ghost-note tests pass 12/12 across 6 repeats
- `npm run build` and `tsc --noEmit` clean

**Known residual flake, not from this PR:** `welcome note is not re-created on subsequent login` and occasionally `cross-session sync` still fail intermittently. That is the already-filed welcome-note seeding race, **#78**. Base-vs-branch on 3 runs each with the harness fix applied: base failed 1/3, this branch passed 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)