### PR TITLE
Undo/redo for note actions (z / Shift+Z)

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -2236,3 +2236,279 @@ test.describe("Compose in search context (#93, #99, #100, #101)", () => {
     await expect(editorOf(page)).toHaveValue(" #tasks-today");
   });
 });
+
+test.describe("Undo / redo note actions (#117)", () => {
+  const items = (page: import("@playwright/test").Page) =>
+    page.getByTestId("list-pane").getByTestId("note-item");
+  const archived = (page: import("@playwright/test").Page) =>
+    page.locator("[data-testid='note-item'][data-archived='true']");
+  const selected = (page: import("@playwright/test").Page) =>
+    page.locator("[data-testid='note-item'][data-selected='true']");
+
+  test.describe("archive", () => {
+    test("z un-archives the note archived by Shift+Y", async ({ page }) => {
+      await page.keyboard.press("Shift+Y");
+      await expect(archived(page)).toHaveCount(1);
+      await page.keyboard.press("z");
+      await expect(archived(page)).toHaveCount(0);
+      await expect(page.getByTestId("archived-divider")).not.toBeVisible();
+    });
+
+    test("undoing an archive strips the #archived tag from the content", async ({ page }) => {
+      // Literal rather than the rendered list title, which carries the ○ pin bullet
+      await expect(page.getByTestId("content-pane")).toContainText("Welcome to notedude");
+      await page.keyboard.press("Shift+Y");
+      await page.keyboard.press("z");
+      // The restored note is selected, so the content pane shows it
+      await expect(page.getByTestId("content-pane")).toContainText("Welcome to notedude");
+      await expect(page.getByTestId("content-pane")).not.toContainText("#archived");
+    });
+
+    test("undo selects the restored note, not whatever archiving moved to", async ({ page }) => {
+      const title = await items(page).first().getByTestId("note-item-title").textContent();
+      await page.keyboard.press("Shift+Y");
+      // Archiving moved the selection off the archived note
+      await expect(selected(page)).toHaveAttribute("data-archived", "false");
+      await page.keyboard.press("z");
+      await expect(selected(page).getByTestId("note-item-title")).toContainText(title!.trim());
+    });
+
+    test("Shift+Z re-archives the note", async ({ page }) => {
+      await page.keyboard.press("Shift+Y");
+      await page.keyboard.press("z");
+      await expect(archived(page)).toHaveCount(0);
+      await page.keyboard.press("Shift+Z");
+      await expect(archived(page)).toHaveCount(1);
+    });
+
+    test("three archives are undone one at a time, newest first", async ({ page }) => {
+      const first = (await items(page).nth(0).getByTestId("note-item-title").textContent())!.trim();
+      const second = (await items(page).nth(1).getByTestId("note-item-title").textContent())!.trim();
+      const third = (await items(page).nth(2).getByTestId("note-item-title").textContent())!.trim();
+      await page.keyboard.press("Shift+Y");
+      await page.keyboard.press("Shift+Y");
+      await page.keyboard.press("Shift+Y");
+      await expect(archived(page)).toHaveCount(3);
+
+      // Each z restores the most recent archive first
+      await page.keyboard.press("z");
+      await expect(archived(page)).toHaveCount(2);
+      await expect(selected(page).getByTestId("note-item-title")).toContainText(third);
+      await page.keyboard.press("z");
+      await expect(archived(page)).toHaveCount(1);
+      await expect(selected(page).getByTestId("note-item-title")).toContainText(second);
+      await page.keyboard.press("z");
+      await expect(archived(page)).toHaveCount(0);
+      await expect(selected(page).getByTestId("note-item-title")).toContainText(first);
+    });
+
+    test("an edit made after archiving survives the undo", async ({ page }) => {
+      await page.keyboard.press("Shift+Y");
+      // Reach the archived note and append text to it
+      await archived(page).first().click();
+      await page.getByTestId("app").focus();
+      await page.keyboard.press("Enter");
+      await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+      const editor = page.getByTestId("content-pane").getByRole("textbox");
+      await editor.pressSequentially(" LATER-EDIT");
+      await page.keyboard.press("Escape");
+      await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+
+      await page.keyboard.press("z");
+      // Undo strips the tag from the content as it stands now — it does not roll the
+      // content back to the snapshot taken at archive time
+      await expect(page.getByTestId("content-pane")).toContainText("LATER-EDIT");
+      await expect(page.getByTestId("content-pane")).not.toContainText("#archived");
+      await expect(archived(page)).toHaveCount(0);
+    });
+  });
+
+  test.describe("pinning", () => {
+    test("z restores the previous pinned state", async ({ page }) => {
+      // Note 2 in the list is unpinned to start with
+      await items(page).nth(1).click();
+      await page.getByTestId("app").focus();
+      const target = selected(page);
+      await expect(target).toHaveAttribute("data-pinned", "false");
+      await page.keyboard.press("p");
+      await expect(selected(page)).toHaveAttribute("data-pinned", "true");
+      await page.keyboard.press("z");
+      await expect(selected(page)).toHaveAttribute("data-pinned", "false");
+    });
+
+    test("Shift+Z re-pins", async ({ page }) => {
+      await items(page).nth(1).click();
+      await page.getByTestId("app").focus();
+      await page.keyboard.press("p");
+      await page.keyboard.press("z");
+      await expect(selected(page)).toHaveAttribute("data-pinned", "false");
+      await page.keyboard.press("Shift+Z");
+      await expect(selected(page)).toHaveAttribute("data-pinned", "true");
+    });
+
+    test("undoing a pin on an already-pinned note restores pinned, not unpinned", async ({ page }) => {
+      // The first note starts pinned; p unpins it, z must put it back
+      await expect(items(page).first()).toHaveAttribute("data-pinned", "true");
+      await page.keyboard.press("p");
+      await expect(selected(page)).toHaveAttribute("data-pinned", "false");
+      await page.keyboard.press("z");
+      await expect(selected(page)).toHaveAttribute("data-pinned", "true");
+    });
+
+    test("z restores the previous tag-pinned state", async ({ page }) => {
+      await items(page).nth(1).click();
+      await page.getByTestId("app").focus();
+      await expect(selected(page)).toHaveAttribute("data-tagpinned", "false");
+      await page.keyboard.press("Shift+P");
+      await expect(selected(page)).toHaveAttribute("data-tagpinned", "true");
+      await page.keyboard.press("z");
+      await expect(selected(page)).toHaveAttribute("data-tagpinned", "false");
+      await page.keyboard.press("Shift+Z");
+      await expect(selected(page)).toHaveAttribute("data-tagpinned", "true");
+    });
+  });
+
+  test.describe("task move", () => {
+    async function moveToTaskList(page: import("@playwright/test").Page) {
+      await page.keyboard.press("t");
+      await page.keyboard.press("m");
+      await expect(page.getByTestId("task-move-overlay")).toBeVisible();
+      await page.keyboard.press("Enter");
+      await expect(page.getByTestId("task-move-overlay")).not.toBeVisible();
+    }
+
+    test("z removes a task tag the move had added", async ({ page }) => {
+      await moveToTaskList(page);
+      await expect(page.getByTestId("content-pane")).toContainText("#tasks-inbox");
+      await page.keyboard.press("z");
+      await expect(page.getByTestId("content-pane")).not.toContainText("#tasks-inbox");
+      await expect(page.getByTestId("content-pane")).not.toContainText("#tasks-");
+    });
+
+    test("Shift+Z re-applies the task tag", async ({ page }) => {
+      await moveToTaskList(page);
+      await page.keyboard.press("z");
+      await expect(page.getByTestId("content-pane")).not.toContainText("#tasks-inbox");
+      await page.keyboard.press("Shift+Z");
+      await expect(page.getByTestId("content-pane")).toContainText("#tasks-inbox");
+    });
+
+    test("z restores the note's previous task tag rather than removing it", async ({ page }) => {
+      // First move puts the note in #tasks-inbox
+      await moveToTaskList(page);
+      await expect(page.getByTestId("content-pane")).toContainText("#tasks-inbox");
+      // Second move sends it to a different list
+      await page.keyboard.press("t");
+      await page.keyboard.press("m");
+      await expect(page.getByTestId("task-move-overlay")).toBeVisible();
+      await page.keyboard.press("j");
+      await page.keyboard.press("Enter");
+      await expect(page.getByTestId("content-pane")).not.toContainText("#tasks-inbox");
+      // Undo goes back to #tasks-inbox, not to no tag at all
+      await page.keyboard.press("z");
+      await expect(page.getByTestId("content-pane")).toContainText("#tasks-inbox");
+    });
+
+    test("z undoes a task move made by clicking the overlay", async ({ page }) => {
+      await page.keyboard.press("t");
+      await page.keyboard.press("m");
+      await page.getByTestId("task-move-item").first().click();
+      await expect(page.getByTestId("task-move-overlay")).not.toBeVisible();
+      await expect(page.getByTestId("content-pane")).toContainText("#tasks-inbox");
+      await page.getByTestId("app").focus();
+      await page.keyboard.press("z");
+      await expect(page.getByTestId("content-pane")).not.toContainText("#tasks-inbox");
+    });
+  });
+
+  test.describe("stack semantics", () => {
+    test("z on an empty undo stack does nothing", async ({ page }) => {
+      const before = await page.getByTestId("content-pane").textContent();
+      await page.keyboard.press("z");
+      await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+      await expect(archived(page)).toHaveCount(0);
+      expect(await page.getByTestId("content-pane").textContent()).toBe(before);
+    });
+
+    test("Shift+Z on an empty redo stack does nothing", async ({ page }) => {
+      const before = await page.getByTestId("content-pane").textContent();
+      await page.keyboard.press("Shift+Z");
+      await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+      expect(await page.getByTestId("content-pane").textContent()).toBe(before);
+    });
+
+    test("a new action after an undo clears the redo stack", async ({ page }) => {
+      await page.keyboard.press("Shift+Y");
+      await page.keyboard.press("z");
+      await expect(archived(page)).toHaveCount(0);
+      // New action: pin the currently selected note
+      await page.keyboard.press("p");
+      const pinnedNow = await selected(page).getAttribute("data-pinned");
+      // Redo must not resurrect the undone archive
+      await page.keyboard.press("Shift+Z");
+      await expect(archived(page)).toHaveCount(0);
+      await expect(selected(page)).toHaveAttribute("data-pinned", pinnedNow!);
+    });
+
+    test("undo past the bottom of the stack stops instead of wrapping", async ({ page }) => {
+      await page.keyboard.press("Shift+Y");
+      await page.keyboard.press("z");
+      await expect(archived(page)).toHaveCount(0);
+      for (let i = 0; i < 3; i++) await page.keyboard.press("z");
+      await expect(archived(page)).toHaveCount(0);
+      await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+    });
+  });
+
+  test.describe("mode isolation", () => {
+    test("z in the editor types a literal z and does not undo", async ({ page }) => {
+      await page.keyboard.press("Shift+Y");
+      await expect(archived(page)).toHaveCount(1);
+      await page.keyboard.press("Enter");
+      await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+      const editor = page.getByTestId("content-pane").getByRole("textbox");
+      await editor.fill("");
+      await editor.pressSequentially("z");
+      await expect(editor).toHaveValue("z");
+      // The archive is untouched
+      await expect(archived(page)).toHaveCount(1);
+    });
+
+    test("Shift+Z in the editor types a literal Z and does not redo", async ({ page }) => {
+      await page.keyboard.press("Shift+Y");
+      await page.keyboard.press("z");
+      await expect(archived(page)).toHaveCount(0);
+      await page.keyboard.press("Enter");
+      await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+      const editor = page.getByTestId("content-pane").getByRole("textbox");
+      await editor.fill("");
+      await editor.pressSequentially("Z");
+      await expect(editor).toHaveValue("Z");
+      await expect(archived(page)).toHaveCount(0);
+    });
+
+    test("z in search types into the search box and does not undo", async ({ page }) => {
+      await page.keyboard.press("Shift+Y");
+      await expect(archived(page)).toHaveCount(1);
+      await page.keyboard.press("/");
+      await expect(page.getByTestId("app")).toHaveAttribute("data-state", "search");
+      const searchInput = page.getByTestId("top-pane").getByRole("searchbox");
+      await searchInput.pressSequentially("z");
+      await expect(searchInput).toHaveValue("z");
+      // Search filters live, so the archived note is now hidden by the query rather than
+      // by an undo. Clear the query and return to idle before counting.
+      await searchInput.fill("");
+      await page.keyboard.press("Escape");
+      await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+      await expect(archived(page)).toHaveCount(1);
+    });
+  });
+
+  test("z and Shift+Z are listed in the help overlay", async ({ page }) => {
+    await page.keyboard.press("?");
+    const overlay = page.getByTestId("help-overlay");
+    await expect(overlay).toBeVisible();
+    await expect(overlay).toContainText("undo last note action");
+    await expect(overlay).toContainText("redo last undone note action");
+  });
+});

--- a/e2e/firebase-roundtrip.spec.ts
+++ b/e2e/firebase-roundtrip.spec.ts
@@ -334,3 +334,87 @@ test("an untouched tag-seeded note is never written to Firestore (#99)", async (
   await expect(page.getByTestId("note-item-title").filter({ hasText: /^\s*#work\s*$/ })).toHaveCount(0);
   await expect(page.getByTestId("note-item-title").filter({ hasText: "New Note" })).toHaveCount(0);
 });
+
+test.describe("Note actions round-trip through Firestore (#117, #118)", () => {
+  // Gets past the seeded welcome note to a note with content we control.
+  async function seedNote(page: Page, content: string) {
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(1, { timeout: 10000 });
+    await page.keyboard.press("c");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+    await page.getByTestId("content-pane").getByRole("textbox").fill(content);
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+    await page.waitForTimeout(500);
+  }
+
+  async function reloadAndSignIn(page: Page) {
+    await page.waitForTimeout(500);
+    await page.reload();
+    await signInViaPage(page);
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle", { timeout: 10000 });
+  }
+
+  test("Shift+Y stores #archived exactly once (#118)", async ({ page, baseURL }) => {
+    await loadAndSignIn(page, baseURL!);
+    await seedNote(page, "Archive me");
+    await page.getByTestId("app").focus();
+    await page.keyboard.press("Shift+Y");
+    await expect(page.locator("[data-testid='note-item'][data-archived='true']")).toHaveCount(1);
+
+    await reloadAndSignIn(page);
+    // Read the stored content back. The UI suite cannot catch a doubled tag: it renders
+    // local state, which only ever had one. Firestore is where the duplicate showed up.
+    await page.locator("[data-testid='note-item'][data-archived='true']").first().click();
+    const content = await page.getByTestId("content-pane").textContent();
+    expect(content).toContain("Archive me");
+    expect(content!.match(/#archived/g) ?? []).toHaveLength(1);
+  });
+
+  test("undoing an archive persists the un-archive", async ({ page, baseURL }) => {
+    await loadAndSignIn(page, baseURL!);
+    await seedNote(page, "Undo my archive");
+    await page.getByTestId("app").focus();
+    await page.keyboard.press("Shift+Y");
+    await expect(page.locator("[data-testid='note-item'][data-archived='true']")).toHaveCount(1);
+    await page.keyboard.press("z");
+    await expect(page.locator("[data-testid='note-item'][data-archived='true']")).toHaveCount(0);
+
+    await reloadAndSignIn(page);
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(2, { timeout: 10000 });
+    await expect(page.locator("[data-testid='note-item'][data-archived='true']")).toHaveCount(0);
+  });
+
+  test("undoing a pin persists", async ({ page, baseURL }) => {
+    await loadAndSignIn(page, baseURL!);
+    await seedNote(page, "Undo my pin");
+    await page.getByTestId("app").focus();
+    await page.keyboard.press("p");
+    await expect(page.locator("[data-testid='note-item'][data-selected='true']")).toHaveAttribute("data-pinned", "true");
+    await page.keyboard.press("z");
+    await expect(page.locator("[data-testid='note-item'][data-selected='true']")).toHaveAttribute("data-pinned", "false");
+
+    await reloadAndSignIn(page);
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(2, { timeout: 10000 });
+    await expect(page.locator("[data-testid='note-item'][data-pinned='true']")).toHaveCount(0);
+  });
+
+  test("undoing a task move persists", async ({ page, baseURL }) => {
+    await loadAndSignIn(page, baseURL!);
+    await seedNote(page, "Undo my task move");
+    await page.getByTestId("app").focus();
+    await page.keyboard.press("t");
+    await page.keyboard.press("m");
+    await expect(page.getByTestId("task-move-overlay")).toBeVisible();
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("content-pane")).toContainText("#tasks-inbox");
+    await page.keyboard.press("z");
+    await expect(page.getByTestId("content-pane")).not.toContainText("#tasks-inbox");
+
+    await reloadAndSignIn(page);
+    await page.getByTestId("list-pane").getByTestId("note-item")
+      .filter({ hasText: "Undo my task move" }).first().click();
+    const content = await page.getByTestId("content-pane").textContent();
+    expect(content).toContain("Undo my task move");
+    expect(content).not.toContain("#tasks-");
+  });
+});

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -184,7 +184,7 @@ server.tool(
     if (!snap.exists) return { content: [{ type: "text", text: `Note ${id} not found.` }] };
     const current: string = snap.data()?.content ?? "";
     const title = current.split("\n")[0] || "untitled";
-    // The app hides notes by the #archived tag in content (see archiveNote), not by a field.
+    // The app hides notes by the #archived tag in content (see Shift+Y), not by a field.
     if (/#archived(?=[\s,.]|$)/i.test(current)) {
       return { content: [{ type: "text", text: `Note ${id} ("${title}") is already archived.` }] };
     }

--- a/spec.md
+++ b/spec.md
@@ -143,6 +143,8 @@ SS → 'Esc Esc'              → IS    (message filter cleared)
 | `d` then `m`     | IS         | Toggle dark/light mode                                      |
 | `l` then `l`     | IS         | Log out the current user                                    |
 | `Shift+Y`        | IS         | Archive the selected note (appends `#archived` tag, moves it to the archived section at the end of the list); select next active note |
+| `z`              | IS         | Undo the last note action (archive / pin / tag-pin / task-move). Does **not** undo text edits |
+| `Shift+Z`        | IS         | Redo the last undone note action            |
 | `Esc`            | ES         | Save edits, return to idle                  |
 | `Cmd/Ctrl+Enter` | ES         | Save edits, return to idle                  |
 | `Enter`          | SS         | Apply filter, return to idle                |
@@ -179,6 +181,7 @@ Pressing `t` then `m` in Idle State opens a task-move overlay on the selected no
   - Otherwise the tag is appended to the note content
   - The note is saved immediately
 - `Esc` dismisses the overlay without changes
+- Applying a tag is reversible with `z` — see **Undo / Redo**
 - Has `data-testid="task-move-overlay"`
 
 ## Archive
@@ -193,7 +196,39 @@ Pressing `Shift+Y` in Idle State archives the selected note:
 - Archived notes are displayed at 50% opacity to distinguish them from active notes
 - Archived notes are **keyboard-reachable**: `j` / `k` / `↑` / `↓` and the `1`–`9` jump keys traverse the whole list — active notes first, then archived notes
 - After archiving, the next **active** note is selected (or the previous one if it was the last). Selection does not jump into the archived section
+- Archiving is reversible with `z` — see **Undo / Redo**
 - Tags that appear only on archived notes are not offered as suggestions — see Tags
+
+## Undo / Redo
+
+`z` undoes the last **note action**; `Shift+Z` redoes it. Both are Idle State only.
+
+### What is undoable
+
+Only actions taken *on* a note — the ones a single keystroke can perform, and therefore the ones a single mis-keystroke can perform by accident:
+
+| Action              | Shortcut                | Reversal                                                        |
+|---------------------|-------------------------|-----------------------------------------------------------------|
+| Archive             | `Shift+Y`               | Strip the `#archived` tag                                        |
+| Pin                 | `p`                     | Restore the previous `pinned` value                              |
+| Tag-pin             | `Shift+P`               | Restore the previous `tagPinned` value                           |
+| Move to task list   | `t` → `m` (or overlay click) | Restore the previous `#tasks-*` tag, or remove it if the note had none |
+
+### What is not
+
+**Text editing is deliberately excluded.** The editor is a plain `<textarea>` and the browser already provides native undo inside it; an app-level stack layered on top would fight it. Consequently `z` and `Shift+Z` are bound only in Idle State — in Editing State they type a literal `z`, and in Search State they type into the search bar.
+
+Note *creation* and the discard of an untouched note are also excluded: creation is not destructive, and a discarded note by definition held nothing the user wrote.
+
+### Semantics
+
+- Two stacks, the standard linear model: performing a new action pushes it onto the undo stack and **clears the redo stack**.
+- `z` on an empty undo stack and `Shift+Z` on an empty redo stack are silent no-ops.
+- Undo and redo **select the affected note**, so the result of the reversal is visible. This matters most for archive, which moves the selection elsewhere when it fires.
+- Entries record a **transform, not a content snapshot**. Undoing an archive strips `#archived` from the note's content *as it currently stands*, rather than restoring the content captured at archive time. A snapshot would silently discard any edit made between the action and the undo.
+- An entry whose note no longer exists (discarded in the meantime) is **skipped**, and the undo moves on to the next entry down the stack.
+- The stacks are in-memory and per-session: reloading the app clears them.
+- Reversals are persisted the same way the forward action is, via the field-level writes described under **Write semantics**.
 
 ## Dark Mode
 
@@ -358,6 +393,7 @@ A note `#client-acme Status update...` with `tagPinned = true` will appear first
 - **Filter clear**: Pressing Esc twice (within 500ms) in IS or SS clears the filter and shows all notes
 - **Pinning**: Pinned notes appear at the top of the List Pane in idle mode. In search/filter mode they behave like regular notes
 - **Tag-pinning**: Tag-pinned notes appear at the top of filtered results when their first tag matches the active search query
+- **Undo/redo**: `z` / `Shift+Z` reverse and reapply the last **note action** (archive, pin, tag-pin, task-move). Text edits are not covered — see **Undo / Redo**
 - **Auto-save**: Edits are saved automatically on state transition out of ES
 - **Welcome note**: On first login (Firestore returns zero notes), a welcome note is automatically created with content `"Greetings\nPress ⌘/ (Ctrl+/) for keyboard shortcuts."`. It is created only once — subsequent logins with existing notes do not re-create it. The welcome note appears at the top of the note list and opens in **read (idle) mode**, never edit mode.
 
@@ -395,6 +431,7 @@ Notes live at `users/{userId}/notes/{noteId}`.
 ### Write semantics (avoiding lost updates)
 - A note's **content** is written with a full-document `setDoc` (create and content-edit). No write is issued when the note is created — only once the user types (see **Composing a Note**).
 - **Metadata-only toggles** — `pinned` (`p`) and `tagPinned` (`Shift+P`) — are written with a **field-level `updateDoc`** that touches only the toggled field and `updatedAt`. They must **not** rewrite `content`. This prevents a stale in-memory snapshot in one tab/device from overwriting a concurrent content edit made elsewhere (lost update). See #74.
+- **Tag-only content changes** — archive/unarchive (`Shift+Y`, `z`) and task-move (`t` → `m`) — go through `setNoteContent(uid, noteId, content)`, a field-level `updateDoc` of `content` + `updatedAt`. The caller owns the tag arithmetic; the helper writes exactly the content it is handed and nothing else. The predecessor `archiveNote()` appended `#archived` itself while its only caller had already appended it, so Firestore received `#archived` twice — invisible to the UI suite, which reads local state. See #118.
 
 ### Authentication bypass guard
 - `NEXT_PUBLIC_SKIP_AUTH=true` renders the app without the sign-in screen for local development. This bypass is **disabled in production builds** (`NODE_ENV === "production"`), so a leaked or mis-set env var can never disable authentication on the deployed site.
@@ -408,4 +445,4 @@ Firebase Hosting serves these response headers on all routes (configured in `fir
 - `Permissions-Policy: geolocation=(), microphone=(), camera=()`
 
 ### MCP archive consistency
-- The MCP `delete_note` tool performs a **soft archive** consistent with the app: it appends a `#archived` tag to the note's content (matching `Shift+Y` / `archiveNote()`), rather than setting a separate field. This ensures notes archived via MCP are hidden in the app's Idle State exactly like notes archived in-app. It is idempotent — a note already tagged `#archived` is left unchanged.
+- The MCP `delete_note` tool performs a **soft archive** consistent with the app: it appends a `#archived` tag to the note's content (matching `Shift+Y`), rather than setting a separate field. This ensures notes archived via MCP are hidden in the app's Idle State exactly like notes archived in-app. It is idempotent — a note already tagged `#archived` is left unchanged.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useRef, useEffect, useCallback } from "react";
-import { subscribeToNotes, saveNote, setNotePinned, setNoteTagPinned, archiveNote, type NoteData } from "../lib/notes";
+import { subscribeToNotes, saveNote, setNotePinned, setNoteTagPinned, setNoteContent, type NoteData } from "../lib/notes";
 import { takePendingShare } from "../lib/share";
 
 interface Note {
@@ -113,6 +113,47 @@ const ARCHIVED_RE = /#archived(?=[\s,.]|$)/i;
 function isArchived(note: Note): boolean {
   return ARCHIVED_RE.test(note.content);
 }
+
+const TASK_TAG_RE = /#tasks-[\w-]+/;
+
+// --- Tag arithmetic ---------------------------------------------------------------
+// Every tag-only content change goes through these, so that adding a tag and taking it
+// away again are exact inverses. Callers own the arithmetic and hand the finished string
+// to setNoteContent(), which writes it verbatim — see #118.
+
+function appendTag(content: string, tag: string): string {
+  const sep = content.endsWith("\n") || content === "" ? "" : " ";
+  return content + sep + tag;
+}
+
+// Removes a tag along with the single space appendTag put in front of it.
+function stripTag(content: string, tag: string): string {
+  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return content.replace(new RegExp(`[ \\t]?${escaped}(?=[\\s,.]|$)`, "i"), "");
+}
+
+// Puts `tag` on the note, replacing whatever #tasks-* tag it already carries. A note
+// belongs to exactly one task list.
+function withTaskTag(content: string, tag: string): string {
+  return TASK_TAG_RE.test(content) ? content.replace(TASK_TAG_RE, tag) : appendTag(content, tag);
+}
+
+function withoutTaskTag(content: string): string {
+  const current = content.match(TASK_TAG_RE)?.[0];
+  return current ? stripTag(content, current) : content;
+}
+
+/**
+ * One reversible action on a note (#117). Entries record a *transform*, never a content
+ * snapshot: undoing an archive strips `#archived` from the content as it stands at undo
+ * time, so an edit made in between survives. Restoring a snapshot would silently discard
+ * it. Text editing is not represented here — the textarea has native browser undo.
+ */
+type NoteAction =
+  | { kind: "archive"; noteId: string }
+  | { kind: "pin"; noteId: string; before: boolean }
+  | { kind: "tagPin"; noteId: string; before: boolean }
+  | { kind: "taskMove"; noteId: string; before: string | null; after: string };
 
 // Callers pass active (non-archived) notes only: a tag whose last remaining note has been
 // archived is no longer in use and must stop being suggested. See #90.
@@ -430,6 +471,93 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
     saveTimerRef.current = setTimeout(flushSave, 500);
   }, [uid, flushSave]);
 
+  // --- Undo / redo (#117) ---------------------------------------------------------
+  // Refs, not state: nothing renders the stacks, and a ref cannot be read stale by the
+  // keydown handler. In-memory and per-session — a reload starts with both empty.
+  const undoStackRef = useRef<NoteAction[]>([]);
+  const redoStackRef = useRef<NoteAction[]>([]);
+
+  const pushAction = useCallback((action: NoteAction) => {
+    undoStackRef.current.push(action);
+    // Standard linear model: a fresh action abandons the redo branch.
+    redoStackRef.current = [];
+  }, []);
+
+  // Applies `action` in one direction. Returns false when the note no longer exists, so
+  // the caller can skip the entry instead of spending the keystroke doing nothing.
+  const applyAction = useCallback((action: NoteAction, direction: "undo" | "redo"): boolean => {
+    const note = notesRef.current.find((n) => n.id === action.noteId);
+    if (!note) return false;
+
+    const writeContent = (content: string) => {
+      setNotes((prev) => prev.map((n) => n.id === note.id ? { ...n, content, updatedAt: Date.now() } : n));
+      if (uid && !demo) setNoteContent(uid, note.id, content);
+    };
+
+    switch (action.kind) {
+      case "archive":
+        writeContent(direction === "undo"
+          ? stripTag(note.content, "#archived")
+          : appendTag(note.content, "#archived"));
+        break;
+      case "pin": {
+        const pinned = direction === "undo" ? action.before : !action.before;
+        setNotes((prev) => prev.map((n) => n.id === note.id ? { ...n, pinned } : n));
+        if (uid && !demo) setNotePinned(uid, note.id, pinned);
+        break;
+      }
+      case "tagPin": {
+        const tagPinned = direction === "undo" ? action.before : !action.before;
+        setNotes((prev) => prev.map((n) => n.id === note.id ? { ...n, tagPinned } : n));
+        if (uid && !demo) setNoteTagPinned(uid, note.id, tagPinned);
+        break;
+      }
+      case "taskMove":
+        writeContent(direction === "undo"
+          ? (action.before === null ? withoutTaskTag(note.content) : withTaskTag(note.content, action.before))
+          : withTaskTag(note.content, action.after));
+        break;
+    }
+    // Put the affected note back on screen — archiving in particular moved the selection
+    // elsewhere when it fired, and an undo you cannot see is not obviously an undo.
+    setSelectedId(note.id);
+    return true;
+  }, [uid, demo]);
+
+  const undo = useCallback(() => {
+    while (undoStackRef.current.length > 0) {
+      const action = undoStackRef.current.pop()!;
+      if (applyAction(action, "undo")) {
+        redoStackRef.current.push(action);
+        return;
+      }
+      // Note was discarded since — drop the entry and try the one beneath it.
+    }
+  }, [applyAction]);
+
+  const redo = useCallback(() => {
+    while (redoStackRef.current.length > 0) {
+      const action = redoStackRef.current.pop()!;
+      if (applyAction(action, "redo")) {
+        undoStackRef.current.push(action);
+        return;
+      }
+    }
+  }, [applyAction]);
+
+  // Assign a task tag, replacing any the note already carries. Shared by the overlay's
+  // keyboard and click paths so both record the same undo entry.
+  const applyTaskTag = useCallback((noteId: string, tag: string) => {
+    const note = notesRef.current.find((n) => n.id === noteId);
+    if (!note) return;
+    const before = note.content.match(TASK_TAG_RE)?.[0] ?? null;
+    const content = withTaskTag(note.content, tag);
+    setNotes((prev) => prev.map((n) => n.id === noteId ? { ...n, content, updatedAt: Date.now() } : n));
+    if (uid && !demo) setNoteContent(uid, noteId, content);
+    pushAction({ kind: "taskMove", noteId, before, after: tag });
+    setShowTaskMove(false);
+  }, [uid, demo, pushAction]);
+
   const enterEditing = useCallback((noteId: string) => {
     editingNoteIdRef.current = noteId;
     setSelectedId(noteId);
@@ -656,17 +784,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
         if (e.key === "j" || e.key === "ArrowDown") { setTaskMoveIndex(i => Math.min(i + 1, taskTagsSorted.length - 1)); return; }
         if (e.key === "k" || e.key === "ArrowUp") { setTaskMoveIndex(i => Math.max(i - 1, 0)); return; }
         if (e.key === "Enter" && selectedId) {
-          const tag = taskTagsSorted[taskMoveIndex];
-          setNotes(prev => prev.map(n => {
-            if (n.id !== selectedId) return n;
-            const newContent = /#tasks-[\w-]+/.test(n.content)
-              ? n.content.replace(/#tasks-[\w-]+/, tag)
-              : n.content + (n.content.endsWith("\n") || n.content === "" ? "" : " ") + tag;
-            const updated = { ...n, content: newContent, updatedAt: Date.now() };
-            debouncedSave(updated);
-            return updated;
-          }));
-          setShowTaskMove(false);
+          applyTaskTag(selectedId, taskTagsSorted[taskMoveIndex]);
           return;
         }
         return;
@@ -702,6 +820,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
             const updated = notes.find((n) => n.id === selectedId);
             setNotes((prev) => prev.map((n) => n.id === selectedId ? { ...n, pinned: !n.pinned } : n));
             if (uid && !demo && updated) setNotePinned(uid, updated.id, !updated.pinned);
+            if (updated) pushAction({ kind: "pin", noteId: updated.id, before: updated.pinned });
           }
           return;
         }
@@ -711,7 +830,20 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
             const updated = notes.find((n) => n.id === selectedId);
             setNotes((prev) => prev.map((n) => n.id === selectedId ? { ...n, tagPinned: !n.tagPinned } : n));
             if (uid && !demo && updated) setNoteTagPinned(uid, updated.id, !updated.tagPinned);
+            if (updated) pushAction({ kind: "tagPin", noteId: updated.id, before: updated.tagPinned });
           }
+          return;
+        }
+        // Undo/redo covers actions on notes only — never text edits, which keep the
+        // textarea's native browser undo. Bound in idle alone for that reason (#117).
+        if (e.key === "z" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+          e.preventDefault();
+          undo();
+          return;
+        }
+        if (e.key === "Z" && e.shiftKey && !e.metaKey && !e.ctrlKey) {
+          e.preventDefault();
+          redo();
           return;
         }
         // 'c' composes in context: the new note inherits the active filter's tags, so it
@@ -789,14 +921,14 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
             // Next selection comes from the active list, so it never lands in the archive.
             const idx = displayed.findIndex((n) => n.id === selectedId);
             const next = displayed[idx + 1] ?? displayed[idx - 1] ?? displayed[0] ?? null;
-            setNotes((prev) => prev.map((n) => {
-              if (n.id !== selectedId) return n;
-              const sep = n.content.endsWith("\n") || n.content === "" ? "" : " ";
-              const newContent = n.content + sep + "#archived";
-              const updated = { ...n, content: newContent, updatedAt: Date.now() };
-              if (uid && !demo) archiveNote(uid, updated);
-              return updated;
-            }));
+            // Compute the content once and store exactly that. The old archiveNote()
+            // appended #archived a second time on the way to Firestore (#118).
+            const newContent = appendTag(toArchive.content, "#archived");
+            setNotes((prev) => prev.map((n) =>
+              n.id === selectedId ? { ...n, content: newContent, updatedAt: Date.now() } : n
+            ));
+            if (uid && !demo) setNoteContent(uid, toArchive.id, newContent);
+            pushAction({ kind: "archive", noteId: toArchive.id });
             setSelectedId(next?.id ?? "");
           }
           return;
@@ -964,7 +1096,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [appState, selectedId, filterQuery, activeFilter, displayed, navigable, enterEditing, createNote, saveEdits, demo, notes]);
+  }, [appState, selectedId, filterQuery, activeFilter, displayed, navigable, enterEditing, createNote, saveEdits, demo, notes, undo, redo, pushAction, applyTaskTag]);
 
   const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
     const html = e.clipboardData.getData("text/html");
@@ -1265,6 +1397,8 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
               ]],
               ["etc", [
                 ["Shift+Y", "archive note (tags #archived, moves to end of list)"],
+                ["z",       "undo last note action (archive / pin / task move)"],
+                ["Shift+Z", "redo last undone note action"],
                 ["d → m",   "toggle dark mode"],
                 ["d → d",   "open donate page"],
                 ["r → r",   "report an issue"],
@@ -1306,20 +1440,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
                 key={tag}
                 data-testid="task-move-item"
                 data-selected={i === taskMoveIndex ? "true" : "false"}
-                onClick={() => {
-                  if (!selectedId) return;
-                  const t = tag;
-                  setNotes(prev => prev.map(n => {
-                    if (n.id !== selectedId) return n;
-                    const newContent = /#tasks-[\w-]+/.test(n.content)
-                      ? n.content.replace(/#tasks-[\w-]+/, t)
-                      : n.content + (n.content.endsWith("\n") || n.content === "" ? "" : " ") + t;
-                    const updated = { ...n, content: newContent, updatedAt: Date.now() };
-                    debouncedSave(updated);
-                    return updated;
-                  }));
-                  setShowTaskMove(false);
-                }}
+                onClick={() => { if (selectedId) applyTaskTag(selectedId, tag); }}
                 style={{ padding: "6px 8px", borderRadius: 4, cursor: "pointer", background: i === taskMoveIndex ? (darkMode ? "#444" : "#e8e8e8") : "transparent", color: darkMode ? "#e8e8e8" : "#000" }}
               >
                 {tag}

--- a/src/lib/notes.ts
+++ b/src/lib/notes.ts
@@ -81,11 +81,20 @@ export function setNoteTagPinned(uid: string, noteId: string, tagPinned: boolean
     .catch((err) => console.error("Failed to update tag-pin:", err));
 }
 
-/** Archive a note by appending #archived tag. Fire-and-forget. */
-export function archiveNote(uid: string, note: NoteData) {
-  const ref = doc(db, "users", uid, "notes", note.id);
-  const sep = note.content.endsWith("\n") || note.content === "" ? "" : " ";
-  const content = note.content + sep + "#archived";
+/**
+ * Write a note's content with a field-level update, leaving every other field alone.
+ * Used by the tag-only content changes — archive/unarchive and task-move — where the
+ * caller has already computed the exact content it wants stored.
+ *
+ * This replaces archiveNote(), which appended `#archived` itself even though its only
+ * caller had already appended it, so Firestore ended up with the tag twice. The UI suite
+ * could not see it: it renders local state, which only ever held one. See #118.
+ *
+ * Field-level rather than setDoc for the same reason as setNotePinned — see #74.
+ * Fire-and-forget.
+ */
+export function setNoteContent(uid: string, noteId: string, content: string) {
+  const ref = doc(db, "users", uid, "notes", noteId);
   updateDoc(ref, { content, updatedAt: serverTimestamp() })
-    .catch((err) => console.error("Failed to archive note:", err));
+    .catch((err) => console.error("Failed to update note content:", err));
 }


### PR DESCRIPTION
Closes #117. Closes #118.

## What

`z` undoes the last **action on a note**; `Shift+Z` redoes it.

| Action | Shortcut | Reversal |
|---|---|---|
| Archive | `Shift+Y` | strip `#archived` |
| Pin | `p` | restore previous `pinned` |
| Tag-pin | `Shift+P` | restore previous `tagPinned` |
| Move to task list | `t → m`, keyboard **and** click | restore previous `#tasks-*`, or remove it if there was none |

Archive is the one that motivated this: a single keystroke that moves the note out of the list *and* moves the selection elsewhere. Hit it by accident and the only route back was finding the note in the archive and hand-deleting the tag.

## Text editing is deliberately out of scope

The editor is a plain `<textarea>` with native browser undo. Shadowing that with an app-level stack would be worse than what's already there. So both keys are bound in **idle only** — in editing they type a literal `z`, in search they go to the search box. There are tests for each.

## Design notes

**Entries store a transform, not a content snapshot.** Undoing an archive strips `#archived` from the content *as it stands at undo time*. Restoring a snapshot would silently discard any edit made between the action and the undo — there's a test for exactly that case.

**Undo re-selects the affected note**, since an undo you can't see isn't obviously an undo.

**Stale entries are skipped, not applied.** If the note was discarded in the meantime, undo moves on to the next entry rather than spending the keystroke.

**Stacks are refs, not state.** Nothing renders them, and a ref can't be read stale by the keydown handler.

## Fixes #118 on the way past

Found while building the un-archive path. `archiveNote()` appended `#archived` to the content it was handed — but its only caller had *already* appended it. Local state held one tag; Firestore held two, compounding on every reload.

The entire UI suite was blind to this by construction, **including the #67 regression test that asserts exactly one `#archived`** — it reads the content pane, which renders local state. Verified against pre-fix source: the new roundtrip test reports `Received array: ["#archived", "#archived"]`.

Replaced with `setNoteContent(uid, noteId, content)`, a field-level `updateDoc` per #74 that writes exactly what it's given. The caller now owns the tag arithmetic through shared `appendTag`/`stripTag` helpers, so adding a tag and removing it again are exact inverses. Task-move moved onto the same field-level write instead of the full-document `debouncedSave`.

## Tests

- **22 e2e** (`chromium`): each action's undo and redo, three-deep undo, redo-stack invalidation, empty-stack no-ops, mode isolation for editing and search, and the edit-survives-undo rule.
- **4 roundtrip** (`firebase-roundtrip`): persistence of each reversal, plus the doubled-tag regression, which needs Firestore to be visible at all.

**Full suite: 226/226 `chromium`, 18/18 `firebase-roundtrip`.**

spec.md gains an **Undo / Redo** section and cross-references from Archive, Task-Move Overlay, Keyboard Shortcuts, Behaviors, and Write semantics.

## Note for the reviewer

Port 3000 in my environment was occupied by an unrelated app, and `reuseExistingServer` silently ran the suite against it — worth knowing if you see odd local failures. The full green runs above were against a dedicated port and a Playwright-managed server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)