### PR TITLE
Decide welcome-note seeding from the server, not the first snapshot

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -359,7 +359,11 @@ A note `#client-acme Status update...` with `tagPinned = true` will appear first
 - **Pinning**: Pinned notes appear at the top of the List Pane in idle mode. In search/filter mode they behave like regular notes
 - **Tag-pinning**: Tag-pinned notes appear at the top of filtered results when their first tag matches the active search query
 - **Auto-save**: Edits are saved automatically on state transition out of ES
-- **Welcome note**: On first login (Firestore returns zero notes), a welcome note is automatically created with content `"Greetings\nPress ⌘/ (Ctrl+/) for keyboard shortcuts."`. It is created only once — subsequent logins with existing notes do not re-create it. The welcome note appears at the top of the note list and opens in **read (idle) mode**, never edit mode.
+- **Welcome note**: On first login a welcome note is automatically created with content `"Greetings\nPress ⌘/ (Ctrl+/) for keyboard shortcuts."`. It is created only once — subsequent logins with existing notes do not re-create it. The welcome note appears at the top of the note list and opens in **read (idle) mode**, never edit mode.
+
+  "First login" is decided by an **authoritative server read** (`accountHasNotes()`, a `getDocsFromServer` query limited to one document), not by the first `onSnapshot` callback. That snapshot may be served from the local cache, and an empty cache hit is indistinguishable from a genuinely empty account — so deciding there gave a returning user on a fresh browser a *duplicate* welcome note, written into their own data (#120). A failed check (offline, or refused) counts as **unknown**, never as empty: nothing is seeded until the server answers.
+
+  The seeding decision deliberately lives outside the Firestore subscription, whose callback does nothing but merge. That merge is what protects against lost updates (#74), so it is kept free of any other responsibility.
 
 ## Persistence & Security
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useRef, useEffect, useCallback } from "react";
-import { subscribeToNotes, saveNote, setNotePinned, setNoteTagPinned, archiveNote, type NoteData } from "../lib/notes";
+import { subscribeToNotes, saveNote, setNotePinned, setNoteTagPinned, archiveNote, accountHasNotes, type NoteData } from "../lib/notes";
 import { takePendingShare } from "../lib/share";
 
 interface Note {
@@ -533,16 +533,6 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
     return subscribeToNotes(
       uid,
       (remoteNotes) => {
-        if (!welcomeSeededRef.current && remoteNotes.length === 0) {
-          welcomeSeededRef.current = true;
-          const now = Date.now();
-          const welcome: Note = { id: crypto.randomUUID(), content: "Greetings\nPress ⌘/ (Ctrl+/) for keyboard shortcuts.", pinned: false, tagPinned: false, createdAt: now, updatedAt: now };
-          saveNote(uid, welcome);
-          setNotes([welcome]);
-          setSynced(true);
-          return;
-        }
-        welcomeSeededRef.current = true;
         setNotes((prev) => {
           // Merge: keep local isNew flags, prefer local content for notes being edited
           const remoteMap = new Map(remoteNotes.map((n) => [n.id, n]));
@@ -565,6 +555,44 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
       (err) => console.error("Firestore subscription error:", err)
     );
   }, [uid]);
+
+  // Seed the welcome note, but only for a genuinely new account.
+  //
+  // Deliberately kept off the subscription above. Its first snapshot can be an empty cache
+  // hit, which is indistinguishable from a new account, so deciding there handed returning
+  // users a duplicate welcome note — written into their own Firestore data (#120). An
+  // authoritative server read answers the question directly and leaves the merge untouched,
+  // which matters because the lost-update guard in #74 depends on its exact behaviour.
+  useEffect(() => {
+    if (!uid || demo) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        if (await accountHasNotes(uid)) return;
+        if (cancelled || welcomeSeededRef.current) return;
+        welcomeSeededRef.current = true;
+        const now = Date.now();
+        const welcome: Note = {
+          id: crypto.randomUUID(),
+          content: "Greetings\nPress ⌘/ (Ctrl+/) for keyboard shortcuts.",
+          pinned: false,
+          tagPinned: false,
+          createdAt: now,
+          updatedAt: now,
+        };
+        saveNote(uid, welcome);
+        setNotes((prev) => (prev.length === 0 ? [welcome] : prev));
+        setSynced(true);
+      } catch (err) {
+        // Offline, or the read was refused. Treat that as "unknown", never as "empty":
+        // seeding on an unanswered question is the bug this replaced.
+        console.error("Welcome-note check failed:", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [uid, demo]);
 
   // Demo mode: persist notes to localStorage on every change
   useEffect(() => {

--- a/src/lib/notes.ts
+++ b/src/lib/notes.ts
@@ -6,6 +6,9 @@ import {
   updateDoc,
   serverTimestamp,
   Timestamp,
+  getDocsFromServer,
+  query,
+  limit,
 } from "firebase/firestore";
 import { db } from "./firebase";
 
@@ -21,6 +24,22 @@ export interface NoteData {
 
 function userNotesCol(uid: string) {
   return collection(db, "users", uid, "notes");
+}
+
+/**
+ * Whether the account already holds at least one note, answered by the **server**.
+ *
+ * Deliberately not derived from the first `onSnapshot` callback: that snapshot can be an
+ * empty cache hit, which is indistinguishable from a genuinely new account and made
+ * returning users seed a duplicate welcome note into their own data (#120). Reads a single
+ * document — the count does not matter, only whether any exist.
+ *
+ * Throws when offline (the server cannot be reached); callers must treat that as "unknown"
+ * rather than "empty".
+ */
+export async function accountHasNotes(uid: string): Promise<boolean> {
+  const snap = await getDocsFromServer(query(userNotesCol(uid), limit(1)));
+  return !snap.empty;
 }
 
 /** Subscribe to all notes for a user (including archived). Returns an unsubscribe function. */


### PR DESCRIPTION
Closes #120.

## Bug

`App.tsx` seeded the welcome note whenever a Firestore snapshot arrived empty, without checking whether that snapshot was **authoritative**. `onSnapshot` can serve its first callback from the local cache, and an empty cache hit is indistinguishable from a genuinely new account.

So a returning user opening notedude in a fresh browser, a new profile, or incognito could gain a duplicate "Greetings" note — a real write into their Firestore data, not a display glitch.

`next dev` is slow enough that the server snapshot usually won the race, which is why it never showed up locally. A production build mounts fast enough to lose it, so this only surfaced once CI started testing the artifact that actually ships (#114). The captured failure snapshot showed session 2 holding **both** "Greetings" and the real note.

## Fix

- `accountHasNotes()` — a server-only read (`getDocsFromServer` + `limit(1)`) that answers "does this account already have notes?" directly.
- Seeding moves out of the subscription into its own effect that consults it.
- A failed check (offline, refused) counts as **unknown**, never as empty. Seeding on an unanswered question is the original bug.

The subscription callback is now purely a merge, and that is deliberate: the merge is what protects against lost updates (#74). An earlier attempt threaded snapshot metadata through it and disturbed exactly that reconciliation. `onSnapshot` keeps `includeMetadataChanges: false`, so no extra callbacks are introduced.

## Verification

- `cross-session sync` — the test that exposed this deterministically against the static export — failed in **every** pre-fix export run and now **passes**
- main suite, CI mode against the export: **204/204**
- roundtrip on the dev path: 12/14 and 13/14

## One thing to be aware of

That last number is not a regression. Measured on a clean `main`, the roundtrip suite is **12/14 and 12/14** — it is independently flaky, with the failing test varying run to run. Filed as #122, and it is the real blocker for #119 (emulator in CI).

I had earlier reported that a previous attempt at this fix "regressed 14/14 → 13/14". That was wrong — it rested on a single lucky run of a suite that does not reliably produce one. Corrected on #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)