### PR TITLE
Keep the page from scrolling so the account header stays put

### DIFF
--- a/e2e/firebase-roundtrip.spec.ts
+++ b/e2e/firebase-roundtrip.spec.ts
@@ -334,3 +334,50 @@ test("an untouched tag-seeded note is never written to Firestore (#99)", async (
   await expect(page.getByTestId("note-item-title").filter({ hasText: /^\s*#work\s*$/ })).toHaveCount(0);
   await expect(page.getByTestId("note-item-title").filter({ hasText: "New Note" })).toHaveCount(0);
 });
+
+test.describe("Signed-in layout stays put while searching (#124)", () => {
+  test("the username + logout header never moves and the page never scrolls", async ({ page, baseURL }) => {
+    await loadAndSignIn(page, baseURL!);
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(1, { timeout: 10000 });
+
+    // Enough notes to overflow the viewport, one of them taller than the screen by itself
+    for (let i = 0; i < 10; i++) {
+      await page.keyboard.press("c");
+      await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+      const body = i === 0 ? "\n" + Array.from({ length: 60 }, (_, l) => `line ${l}`).join("\n") : "";
+      await page.getByTestId("content-pane").getByRole("textbox").fill(`Note ${i} #guide${body}`);
+      await page.keyboard.press("Escape");
+      await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+    }
+    await page.waitForTimeout(500);
+
+    const header = page.getByTestId("account-header");
+    await expect(header).toContainText("logout");
+    const idleBox = await header.boundingBox();
+    expect(idleBox!.y).toBeGreaterThanOrEqual(0);
+
+    const stillPut = async (label: string) => {
+      const geom = await page.evaluate(() => ({
+        scrollH: document.documentElement.scrollHeight,
+        innerH: window.innerHeight,
+        scrollY: window.scrollY,
+      }));
+      expect(geom.scrollH, `page must not overflow (${label})`).toBeLessThanOrEqual(geom.innerH);
+      expect(geom.scrollY, `page must not be scrolled (${label})`).toBe(0);
+      await expect(header).toBeVisible();
+      const box = await header.boundingBox();
+      expect(box!.y, `header must not move (${label})`).toBeCloseTo(idleBox!.y, 1);
+    };
+
+    await stillPut("idle with many notes");
+    await page.keyboard.press("/");
+    await page.getByTestId("top-pane").getByRole("searchbox").pressSequentially("#guide");
+    await stillPut("tag dropdown open");
+    await page.keyboard.press("Enter");
+    await stillPut("filter applied");
+    await page.keyboard.press("j");
+    await stillPut("browsing after j");
+    await page.keyboard.press("j");
+    await stillPut("browsing after j j");
+  });
+});

--- a/e2e/layout-stability.spec.ts
+++ b/e2e/layout-stability.spec.ts
@@ -1,0 +1,193 @@
+import { test, expect, Page } from "@playwright/test";
+
+// #124: searching and browsing results used to scroll the whole document, taking the
+// account header off screen and drifting the panes up and down. The app owns exactly the
+// viewport; scrolling belongs to the list and content panes, never to the page.
+
+// Enough notes to overflow the viewport several times over, one of them far taller than
+// the screen on its own — the condition under which the layout used to give way.
+function seedNotes(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `seed-${i}`,
+    content:
+      i === 0
+        ? `Long note #guide\n${Array.from({ length: 80 }, (_, l) => `line ${l}`).join("\n")}`
+        : `Note ${i} #guide\nbody of note ${i}`,
+    pinned: false,
+    tagPinned: false,
+    createdAt: 1000 + i,
+    updatedAt: 1000 + i,
+  }));
+}
+
+// Demo mode renders the same shell as the signed-in page — header row above <App> — but
+// needs no emulator, and its notes come from localStorage so the list can be seeded.
+async function openDemoWithNotes(page: Page, count = 15) {
+  await page.goto("/");
+  await page.evaluate(
+    (notes) => localStorage.setItem("notedude_demo_notes", JSON.stringify(notes)),
+    seedNotes(count)
+  );
+  await page.reload();
+  await expect(page.getByTestId("login-screen")).toBeVisible();
+  await page.keyboard.press("d");
+  await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+  await page.getByTestId("app").focus();
+}
+
+async function pageScroll(page: Page) {
+  return page.evaluate(() => ({
+    scrollH: document.documentElement.scrollHeight,
+    innerH: window.innerHeight,
+    scrollY: window.scrollY,
+  }));
+}
+
+async function expectNoPageScroll(page: Page, label: string) {
+  const s = await pageScroll(page);
+  expect(s.scrollH, `document must not exceed the viewport (${label})`).toBeLessThanOrEqual(s.innerH);
+  expect(s.scrollY, `page must not be scrolled (${label})`).toBe(0);
+}
+
+test.describe("Layout stability: the page never scrolls (#124)", () => {
+  test("document fits the viewport with far more notes than fit on screen", async ({ page }) => {
+    await openDemoWithNotes(page);
+    await expectNoPageScroll(page, "idle, many notes");
+  });
+
+  test("document still fits while searching and browsing results", async ({ page }) => {
+    await openDemoWithNotes(page);
+    await expectNoPageScroll(page, "idle");
+
+    await page.keyboard.press("/");
+    await page.getByTestId("top-pane").getByRole("searchbox").pressSequentially("#guide");
+    await expectNoPageScroll(page, "search, tag dropdown open");
+
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+    await expectNoPageScroll(page, "filter applied");
+
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press("j");
+      await expectNoPageScroll(page, `browsing, after ${i + 1}x j`);
+    }
+  });
+
+  test("selecting a note far longer than the viewport does not grow the page", async ({ page }) => {
+    await openDemoWithNotes(page);
+    // The 80-line note is the oldest, so it sorts last
+    const items = page.getByTestId("list-pane").getByTestId("note-item");
+    await items.last().click();
+    await expect(page.getByTestId("content-pane")).toContainText("Long note");
+    await expectNoPageScroll(page, "long note selected");
+  });
+
+  test("the list pane still scrolls internally when the list is long", async ({ page }) => {
+    await openDemoWithNotes(page);
+    const overflow = await page.getByTestId("list-pane").evaluate((el) => ({
+      scrollH: el.scrollHeight,
+      clientH: el.clientHeight,
+    }));
+    // Containment must not have been achieved by clipping the list away
+    expect(overflow.scrollH).toBeGreaterThan(overflow.clientH);
+  });
+});
+
+test.describe("Layout stability: the account header never moves (#124)", () => {
+  test("header stays fully visible and fixed across search and browsing", async ({ page }) => {
+    await openDemoWithNotes(page);
+    const header = page.getByTestId("account-header");
+    await expect(header).toBeVisible();
+
+    const idleBox = await header.boundingBox();
+    expect(idleBox).not.toBeNull();
+    // Fully inside the viewport, not clipped at the top edge
+    expect(idleBox!.y).toBeGreaterThanOrEqual(0);
+    expect(idleBox!.height).toBeGreaterThan(0);
+
+    const sameAsIdle = async (label: string) => {
+      await expect(header).toBeVisible();
+      const box = await header.boundingBox();
+      expect(box, `header must still be laid out (${label})`).not.toBeNull();
+      expect(box!.y, `header must not move (${label})`).toBeCloseTo(idleBox!.y, 1);
+      expect(box!.height, `header must not resize (${label})`).toBeCloseTo(idleBox!.height, 1);
+    };
+
+    await page.keyboard.press("/");
+    await page.getByTestId("top-pane").getByRole("searchbox").pressSequentially("#guide");
+    await sameAsIdle("tag dropdown open");
+
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+    await sameAsIdle("filter applied");
+
+    await page.keyboard.press("j");
+    await sameAsIdle("after j");
+    await page.keyboard.press("j");
+    await sameAsIdle("after j j");
+
+    // And back out of the filter
+    await page.keyboard.press("Escape");
+    await page.keyboard.press("Escape");
+    await sameAsIdle("filter cleared");
+  });
+
+  test("header is still visible after the whole list is filtered away", async ({ page }) => {
+    await openDemoWithNotes(page);
+    const header = page.getByTestId("account-header");
+    const before = await header.boundingBox();
+
+    await page.keyboard.press("/");
+    await page.getByTestId("top-pane").getByRole("searchbox").pressSequentially("#nothingmatchesthis");
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("list-pane").getByTestId("note-item")).toHaveCount(0);
+
+    await expect(header).toBeVisible();
+    const after = await header.boundingBox();
+    expect(after!.y).toBeCloseTo(before!.y, 1);
+    await expectNoPageScroll(page, "zero results");
+  });
+});
+
+test.describe("Layout stability: the tag dropdown overlays rather than reflows (#124)", () => {
+  test("opening the tag dropdown does not move the list pane", async ({ page }) => {
+    await openDemoWithNotes(page);
+    const listPane = page.getByTestId("list-pane");
+    const before = await listPane.boundingBox();
+
+    await page.keyboard.press("/");
+    await page.getByTestId("top-pane").getByRole("searchbox").pressSequentially("#gu");
+    await expect(page.getByTestId("tag-dropdown")).toBeVisible();
+
+    const during = await listPane.boundingBox();
+    expect(during!.y, "list pane must not be pushed down by the dropdown").toBeCloseTo(before!.y, 1);
+  });
+
+  test("closing the tag dropdown does not move the list pane back", async ({ page }) => {
+    await openDemoWithNotes(page);
+    await page.keyboard.press("/");
+    const search = page.getByTestId("top-pane").getByRole("searchbox");
+    await search.pressSequentially("#gu");
+    await expect(page.getByTestId("tag-dropdown")).toBeVisible();
+
+    const listPane = page.getByTestId("list-pane");
+    const withDropdown = await listPane.boundingBox();
+
+    await search.fill("");
+    await expect(page.getByTestId("tag-dropdown")).not.toBeVisible();
+    const withoutDropdown = await listPane.boundingBox();
+    expect(withoutDropdown!.y).toBeCloseTo(withDropdown!.y, 1);
+  });
+
+  test("the dropdown is still readable on top of the content below it", async ({ page }) => {
+    await openDemoWithNotes(page);
+    await page.keyboard.press("/");
+    await page.getByTestId("top-pane").getByRole("searchbox").pressSequentially("#gu");
+    const dropdown = page.getByTestId("tag-dropdown");
+    await expect(dropdown).toBeVisible();
+    // An overlay with a transparent background would render the list through it
+    const bg = await dropdown.evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bg).not.toBe("rgba(0, 0, 0, 0)");
+    await expect(page.getByTestId("tag-item").first()).toBeVisible();
+  });
+});

--- a/spec.md
+++ b/spec.md
@@ -46,9 +46,26 @@ If no user is signed in when the share arrives, the payload stays parked and is 
 
 The app consists of three panes:
 
+### The page never scrolls
+
+The app owns exactly the viewport and no more. The document itself is **never scrollable**: `scrollHeight` always equals the viewport height, in every state — idle, search, with the tag dropdown open, and while browsing filtered results. Scrolling happens **inside** the list pane and the content pane, never at the page level.
+
+This is a correctness requirement, not a cosmetic one. When the page can scroll, the account header scrolls out of view and the whole UI appears to drift up and down as the note list changes size underneath it. See #124.
+
+Three rules keep it true:
+
+- `html` and `body` carry no margin and are exactly viewport-height. Without this the default 8px body margin alone makes a `100vh` child overflow by 16px.
+- Every flex item in the vertical chain that wraps a scrollable region sets **`min-height: 0`**. A flex item's default `min-height: auto` resolves to its *content's* height, so a `flex: 1` wrapper silently refuses to shrink below its content and pushes the page taller than the viewport. This is what broke it in #124: the wrapper around `<App>` rendered 893px tall inside a 720px `100vh` container.
+- The header row (account email + logout, or the demo-mode banner) is **`flex-shrink: 0`**, so it can never be compressed, and the container clips rather than scrolls.
+
+### Header (account row)
+
+Above the app, the authenticated and demo shells each render a header row. It is **always visible and never moves** — its position must be byte-identical across idle, search, dropdown-open, and result-browsing states. It is outside the app's own scroll regions and cannot be scrolled away.
+
 ### Top Pane (Search Bar)
 - Contains a search/filter input field (similar to Google Keep)
 - Used to filter the message list
+- The tag suggestion dropdown is **overlaid, not inserted into the flow** (`position: absolute`, matching the in-editor completion dropdown). Opening or closing it must not move the panes below it — it used to push them down 48px and pull them back. See #124
 
 ### Left Pane (List Pane)
 - Displays a list of notes in Apple Notes style (see **Note List Item Display** below)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,10 +19,18 @@ export const metadata: Metadata = {
 // preventing a light flash on load.
 const themeScript = `try{document.documentElement.style.backgroundColor=localStorage.getItem('theme')==='light'?'#ffffff':'#1a1a1a';}catch(e){}`;
 
+// The app is sized to the viewport and must never make the document scrollable — a
+// scrolling page takes the account header out of view. The browser's default 8px body
+// margin alone is enough to push a 100vh child past the bottom, so it has to go. There is
+// no stylesheet in this project (everything else is inline styles), hence the inline
+// <style>. See #124.
+const resetStyles = `html,body{margin:0;padding:0;height:100%;overflow:hidden;}`;
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" style={{ backgroundColor: "#1a1a1a" }} suppressHydrationWarning>
       <head>
+        <style dangerouslySetInnerHTML={{ __html: resetStyles }} />
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
         <link rel="icon" href="/notedude-n_d-icon-32.png" sizes="32x32" />
         <link rel="icon" href="/notedude-n_d-icon-16.png" sizes="16x16" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,10 +39,23 @@ export default function Page() {
   const muted = darkMode ? "#888" : "#666";
   const border = darkMode ? "#444" : "#ccc";
 
+  // A flex item's default `min-height: auto` resolves to its *content's* height, so a bare
+  // `flex: 1` wrapper refuses to shrink below the app's content and pushes the page taller
+  // than the viewport — which is what scrolled the header off screen in #124. `minHeight: 0`
+  // lets it shrink to the space actually available; `overflow: hidden` on the shell makes
+  // sure nothing can scroll the page even if something else grows unexpectedly.
+  const shell = { height: "100vh", display: "flex", flexDirection: "column" as const, background: bg, overflow: "hidden" };
+  const appSlot = { flex: 1, minHeight: 0 };
+  // Never compressed, never scrolled away.
+  const headerRow = {
+    display: "flex", justifyContent: "flex-end", padding: "4px 8px", fontSize: 12,
+    fontFamily: "'Fira Code', monospace", color: muted, flexShrink: 0,
+  };
+
   if (SKIP_AUTH) {
     return (
-      <div style={{ height: "100vh", display: "flex", flexDirection: "column", background: bg }}>
-        <div style={{ flex: 1 }}>
+      <div style={shell}>
+        <div style={appSlot}>
           <App />
         </div>
       </div>
@@ -55,14 +68,14 @@ export default function Page() {
 
   if (demoMode) {
     return (
-      <div style={{ height: "100vh", display: "flex", flexDirection: "column", background: bg }}>
-        <div style={{ display: "flex", justifyContent: "flex-end", padding: "4px 8px", fontSize: 12, fontFamily: "'Fira Code', monospace", color: muted }}>
+      <div style={shell}>
+        <div data-testid="account-header" style={headerRow}>
           demo mode —{" "}
           <button onClick={() => setDemoMode(false)} style={{ marginLeft: 6, fontFamily: "inherit", fontSize: "inherit", cursor: "pointer", background: "none", border: "none", textDecoration: "underline", color: muted }}>
             sign in
           </button>
         </div>
-        <div style={{ flex: 1 }}>
+        <div style={appSlot}>
           <App demo onLogout={() => setDemoMode(false)} />
         </div>
       </div>
@@ -84,11 +97,11 @@ export default function Page() {
   }
 
   return (
-    <div style={{ height: "100vh", display: "flex", flexDirection: "column", background: bg }}>
-      <div style={{ display: "flex", justifyContent: "flex-end", padding: "4px 8px", fontSize: 12, fontFamily: "'Fira Code', monospace", color: muted }}>
+    <div style={shell}>
+      <div data-testid="account-header" style={headerRow}>
         {user.email} <button onClick={logout} style={{ marginLeft: 8, fontFamily: "inherit", fontSize: "inherit", cursor: "pointer", background: "none", border: "none", textDecoration: "underline", color: muted }}>logout</button>
       </div>
-      <div style={{ flex: 1 }}>
+      <div style={appSlot}>
         <App uid={user.uid} onLogout={logout} />
       </div>
     </div>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1076,7 +1076,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
   return (
     <div ref={appRef} tabIndex={-1} data-testid="app" data-state={appState} data-theme={darkMode ? "dark" : "light"} style={{ display: "flex", flexDirection: "column", height: "100%", outline: "none", fontFamily: "'Fira Code', monospace", fontSize: 14, background: darkMode ? "#1a1a1a" : "#ffffff", color: darkMode ? "#e8e8e8" : "#000000" }}>
       {/* Top Pane */}
-      <div data-testid="top-pane" style={{ padding: "8px 8px 8px 8px", display: "flex", alignItems: "center" }}>
+      <div data-testid="top-pane" style={{ padding: "8px 8px 8px 8px", display: "flex", alignItems: "center", flexShrink: 0 }}>
         <span style={{ userSelect: "none", marginRight: 4 }}>&gt;</span>
         <input
           ref={searchRef}
@@ -1090,8 +1090,12 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
           style={{ width: "100%", padding: "4px 0", fontFamily: "inherit", fontSize: "inherit", border: "none", outline: "none", background: "transparent", color: "inherit" }}
         />
       </div>
+      {/* Zero-height anchor. The dropdown hangs off it as an overlay rather than sitting in
+          the column, where opening it shoved the panes below down 48px and closing it
+          yanked them back (#124). Mirrors editor-tag-dropdown, which is already absolute. */}
+      <div style={{ position: "relative", zIndex: 20 }}>
       {showTagDropdown && filteredTags.length > 0 && (
-        <div data-testid="tag-dropdown" style={{ padding: "4px 8px", background: darkMode ? "#2a2a2a" : "#f5f5f5" }}>
+        <div data-testid="tag-dropdown" style={{ position: "absolute", top: 0, left: 0, right: 0, padding: "4px 8px", background: darkMode ? "#2a2a2a" : "#f5f5f5", border: `1px solid ${darkMode ? "#444" : "#ddd"}` }}>
           {filteredTags.map(({ tag }, i) => (
             <div key={tag}>
               {i === recentTagCount && recentTagCount > 0 && recentTagCount < filteredTags.length && (
@@ -1109,11 +1113,14 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
           ))}
         </div>
       )}
-      <div style={{ overflow: "hidden", whiteSpace: "nowrap", color: darkMode ? "#555" : "#000", lineHeight: "1.4", userSelect: "none", fontSize: 14 }}>
+      </div>
+      <div style={{ overflow: "hidden", whiteSpace: "nowrap", color: darkMode ? "#555" : "#000", lineHeight: "1.4", userSelect: "none", flexShrink: 0, fontSize: 14 }}>
         {"- ".repeat(300)}
       </div>
 
-      <div style={{ display: "flex", flex: 1, overflow: "hidden" }}>
+      {/* minHeight: 0 so this row shrinks to the space left over instead of being sized by
+          its own content — the divider column alone is hundreds of rows tall (#124). */}
+      <div style={{ display: "flex", flex: 1, minHeight: 0, overflow: "hidden" }}>
         {/* List Pane */}
         {showList && (
         <div ref={listPaneRef} data-testid="list-pane" style={{ width: isNarrow ? "100%" : 250, overflowY: "auto" }}>
@@ -1249,7 +1256,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
           )}
         </div>
       )}
-      <div style={{ padding: "8px", textAlign: "center", fontSize: 12, color: "#888", userSelect: "none" }}>
+      <div style={{ padding: "8px", textAlign: "center", fontSize: 12, color: "#888", userSelect: "none", flexShrink: 0 }}>
         notedude &bull; an <a href="https://nbino.tech" target="_blank" rel="noopener noreferrer" style={{ color: "#888", textDecoration: "underline" }}>nbino</a> production
       </div>
       {showHelp && (


### PR DESCRIPTION
Closes #124.

## The bug

Searching and browsing results made the whole UI drift up and down, and the username + logout header appear and disappear.

The header was being **scrolled off screen**. Measured signed in, 12 notes, 720px viewport:

| state | app height | viewport | doc overflow | header top / bottom |
|---|---|---|---|---|
| idle | **893px** | 720px | 205px | −24 / **0** — fully hidden |
| typing `#guide` | 696px | 720px | 16px | −8 / 16 — partly back |
| filter applied | 854px | 720px | 166px | −24 / **0** — hidden again |

The app rendered **893px tall inside a `100vh` container**. The document overflowed, the page scrolled, and the header — first thing in the column — is what went. Opening the tag dropdown shortened the list, overflow dropped to 16px, and the header slid partly back. That's the appearing and disappearing.

## Cause

`min-height: auto` — the default for a flex item — resolves to the item's **content** height. So `<div style={{ flex: 1 }}>` around `<App>` could never shrink below its content, and the app's content is tall: the `|` divider column's row count is derived from the list height and the selected note's length. That's why the overflow, and the header's visibility, *changed as you searched and browsed*.

Two smaller contributors:
- **No stylesheet exists in this project**, so `body` kept its default 8px margin — enough on its own to push a `100vh` child 16px past the bottom in every state.
- **The tag dropdown sat in the column**, so opening it pushed the panes down 48px and closing it pulled them back.

## Fix

- `minHeight: 0` on the wrapper around `<App>` and on the pane row inside it, so they shrink to the space available rather than to their content.
- `overflow: hidden` on the shell, so nothing can scroll the page even if something else grows unexpectedly.
- `flexShrink: 0` on header, top pane, rule, and footer, so the chrome is never squeezed instead.
- `html`/`body` reset via an inline `<style>` (consistent with the project — everything else is inline styles).
- The tag dropdown now hangs off a zero-height anchor as an overlay, matching `editor-tag-dropdown`, which was already absolute.

All three shells in `page.tsx` — authenticated, demo, `SKIP_AUTH` — share style objects now, so they can't drift apart again.

## Tests

**9 e2e** driving demo mode (same shell as signed-in, no emulator needed, notes seeded through localStorage): the document never exceeds the viewport and the header's box is **identical** across idle, dropdown-open, filtered, browsing, cleared, and zero-result states. **8 of the 9 fail on the pre-fix code.**

**1 roundtrip test** doing the same on the real signed-in page.

One test asserts the list pane still scrolls internally, so containment can't be satisfied by clipping the list away.

**213/213 `chromium`. Roundtrip: my test passes; see the note below.**

## Note for the reviewer

The `firebase-roundtrip` file is **flaky on `main`, independently of this change** — I measured `origin/main` failing 1–2 tests on each of 3 consecutive runs of that file, mostly `welcome note is not re-created on subsequent login`, which passes 3/3 in isolation. This branch behaves the same way. Worth a separate issue; I didn't touch it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)