### PR TITLE
Title a note by its first non-blank line, not literally line 1

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -2236,3 +2236,97 @@ test.describe("Compose in search context (#93, #99, #100, #101)", () => {
     await expect(editorOf(page)).toHaveValue(" #tasks-today");
   });
 });
+
+test.describe("Leading blank lines do not make a note look empty (#126)", () => {
+  // Writes `content` into a fresh note, saves it, and returns its list entry.
+  async function noteWith(page: import("@playwright/test").Page, content: string) {
+    await page.keyboard.press("c");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+    await page.getByTestId("content-pane").getByRole("textbox").fill(content);
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+    return page.getByTestId("list-pane").locator("[data-selected='true']");
+  }
+
+  test("one leading blank line: the first real line is the title", async ({ page }) => {
+    const item = await noteWith(page, "\nBuy milk");
+    await expect(item.getByTestId("note-item-title")).toHaveText("Buy milk");
+    await expect(item.getByTestId("note-item-title")).not.toHaveText("No Text Entered");
+  });
+
+  test("several leading blank lines: the first real line is still the title", async ({ page }) => {
+    const item = await noteWith(page, "\n\n\nBuy milk");
+    await expect(item.getByTestId("note-item-title")).toHaveText("Buy milk");
+  });
+
+  test("a whitespace-only first line is treated as blank", async ({ page }) => {
+    const item = await noteWith(page, "   \nBuy milk");
+    await expect(item.getByTestId("note-item-title")).toHaveText("Buy milk");
+  });
+
+  test("a tab-only first line is treated as blank", async ({ page }) => {
+    const item = await noteWith(page, "\t\nBuy milk");
+    await expect(item.getByTestId("note-item-title")).toHaveText("Buy milk");
+  });
+
+  test("the snippet comes from the line after the title, not blindly from line 2", async ({ page }) => {
+    const item = await noteWith(page, "\nBuy milk\nremember the oat one");
+    await expect(item.getByTestId("note-item-title")).toHaveText("Buy milk");
+    await expect(item.getByTestId("note-item-meta")).toContainText("remember the oat one");
+    await expect(item.getByTestId("note-item-meta")).not.toContainText("No Content");
+  });
+
+  test("blank lines between title and body are skipped for the snippet", async ({ page }) => {
+    const item = await noteWith(page, "\n\nBuy milk\n\n\nremember the oat one");
+    await expect(item.getByTestId("note-item-title")).toHaveText("Buy milk");
+    await expect(item.getByTestId("note-item-meta")).toContainText("remember the oat one");
+  });
+
+  test("a note that is only blank lines still reports no text", async ({ page }) => {
+    // Must be asserted mid-edit: a note holding no text is discarded when editing exits
+    await page.keyboard.press("c");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+    await page.getByTestId("content-pane").getByRole("textbox").fill("\n\n\n");
+    const item = page.getByTestId("list-pane").locator("[data-selected='true']");
+    await expect(item.getByTestId("note-item-title")).toHaveText("No Text Entered");
+    await expect(item.getByTestId("note-item-meta")).toContainText("No Content");
+  });
+
+  test("a whitespace-only note reports no text rather than rendering a blank title", async ({ page }) => {
+    // "   " is a non-empty string, so it used to be accepted as the title and render blank
+    await page.keyboard.press("c");
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "editing");
+    await page.getByTestId("content-pane").getByRole("textbox").fill("   ");
+    const item = page.getByTestId("list-pane").locator("[data-selected='true']");
+    await expect(item.getByTestId("note-item-title")).toHaveText("No Text Entered");
+  });
+
+  test("a note starting with a blank line is still findable by its text", async ({ page }) => {
+    await noteWith(page, "\nBuy milk #errand");
+    await page.keyboard.press("/");
+    await page.getByTestId("top-pane").getByRole("searchbox").pressSequentially("Buy milk");
+    await page.keyboard.press("Enter");
+    const items = page.getByTestId("list-pane").getByTestId("note-item");
+    await expect(items).toHaveCount(1);
+    await expect(items.first().getByTestId("note-item-title")).toHaveText("Buy milk #errand");
+  });
+
+  test("a tag-only note keeps its tag line as the title", async ({ page }) => {
+    // Unchanged behaviour: a tag line is real text, so it titles the note
+    const item = await noteWith(page, "#work #urgent");
+    await expect(item.getByTestId("note-item-title")).toHaveText("#work #urgent");
+    await expect(item.getByTestId("note-item-meta")).toContainText("No Content");
+  });
+
+  test("a tag-only note with a leading blank line keeps its tag line as the title", async ({ page }) => {
+    const item = await noteWith(page, "\n#work #urgent");
+    await expect(item.getByTestId("note-item-title")).toHaveText("#work #urgent");
+    await expect(item.getByTestId("note-item-meta")).toContainText("No Content");
+  });
+
+  test("an ordinary note is unaffected", async ({ page }) => {
+    const item = await noteWith(page, "Buy milk\nremember the oat one");
+    await expect(item.getByTestId("note-item-title")).toHaveText("Buy milk");
+    await expect(item.getByTestId("note-item-meta")).toContainText("remember the oat one");
+  });
+});

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -52,8 +52,14 @@ async function fetchAllNotes(): Promise<Note[]> {
   });
 }
 
+// The first line with something on it — matching the app, where taking line 1 literally
+// made notes that open with a blank line report as empty. See #126.
+function firstNonBlankLine(content: string): string | null {
+  return content.split("\n").find((l) => l.trim() !== "") ?? null;
+}
+
 function noteTitle(note: Note): string {
-  return note.content.split("\n")[0] || "No Text Entered";
+  return firstNonBlankLine(note.content) ?? "No Text Entered";
 }
 
 function formatNote(note: Note): string {
@@ -183,7 +189,7 @@ server.tool(
     const snap = await ref.get();
     if (!snap.exists) return { content: [{ type: "text", text: `Note ${id} not found.` }] };
     const current: string = snap.data()?.content ?? "";
-    const title = current.split("\n")[0] || "untitled";
+    const title = firstNonBlankLine(current) ?? "untitled";
     // The app hides notes by the #archived tag in content (see archiveNote), not by a field.
     if (/#archived(?=[\s,.]|$)/i.test(current)) {
       return { content: [{ type: "text", text: `Note ${id} ("${title}") is already archived.` }] };

--- a/spec.md
+++ b/spec.md
@@ -211,15 +211,25 @@ Each note in the List Pane displays two lines:
 
 | Line | Content | Fallback |
 |------|---------|----------|
-| **Line 1 — Title** | First line of note content | `"New Note"` (just created, blank) / `"No Text Entered"` (content deleted) |
-| **Line 2 — Metadata** | Creation timestamp + abbreviated first line of content | Timestamp + `"No Content"` (when blank) |
+| **Line 1 — Title** | First **non-blank** line of note content | `"New Note"` (just created, blank) / `"No Text Entered"` (no text at all) |
+| **Line 2 — Metadata** | Creation timestamp + abbreviated next non-blank line | Timestamp + `"No Content"` (when there is none) |
 
 Each item carries `data-testid="note-item"` plus state attributes: `data-selected`, `data-pinned`, `data-tagpinned`, `data-flash`, and `data-archived`.
 
 ### Display rules
 - **New note** (created via `c` / `Shift+C`, holding no text beyond any inherited tags): Title = `"New Note"`, metadata = `<timestamp> No Content`. A note seeded with the active filter's tags counts as new until the user types — the tags show in the Content Pane but not in the list placeholders
-- **Note with content**: Title = first line of content, metadata = `<timestamp> <abbreviated first line>`
+- **Note with content**: Title = the **first line that has something on it**, metadata = `<timestamp> <abbreviated following non-blank line>`
 - **Note with all content deleted** (while editing): Title = `"No Text Entered"`, metadata = `<timestamp> No Content`. A note left empty when editing exits is **discarded** (removed from the list) rather than kept — see Behaviors.
+
+### Leading blank lines do not make a note look empty
+
+The title is the first line **with something on it**, not literally line 1, and blank means "nothing but whitespace". A note whose content opens with one or more empty lines is titled by its first real line, and its snippet comes from the next non-blank line **after** that one.
+
+Deriving the title from line 1 alone made any note starting with a blank line report `"No Text Entered"` / `"No Content"` — the list claiming the note was empty while the Content Pane showed its text. A whitespace-only first line was worse: non-empty as a string, so it was used as the title and the entry rendered blank, with no text and no placeholder. See #126.
+
+`"No Text Entered"` and `"No Content"` are reserved for notes that genuinely hold no text, whitespace-only content included.
+
+A note consisting only of `#tags` is unaffected: its tag line is real text, so it remains the title, and the snippet stays `"No Content"`.
 
 ## Composing a Note
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -58,17 +58,31 @@ function inheritedTags(query: string): string[] {
   return Array.from(new Set(tags)).filter((t) => !NON_INHERITABLE_TAGS.has(t));
 }
 
+// Index of the first line with something on it, or -1 if every line is blank. The title is
+// this line, not literally line 1: a note that opens with empty lines still has a title, it
+// just sits further down. Deriving it from line 1 made any such note report "No Text
+// Entered" while the Content Pane plainly showed its text (#126).
+function firstNonBlankIndex(lines: string[]): number {
+  return lines.findIndex((l) => l.trim() !== "");
+}
+
 function getNoteTitle(note: Note): string {
   if (note.isNew && contentWithoutTags(note.content) === "") return "New Note";
-  const firstLine = note.content.split("\n")[0];
-  return firstLine || "No Text Entered";
+  const lines = note.content.split("\n");
+  const titleIdx = firstNonBlankIndex(lines);
+  // Reserved for notes that genuinely hold no text — whitespace-only included, which used
+  // to slip through as a non-empty string and render the entry with no title at all.
+  return titleIdx === -1 ? "No Text Entered" : lines[titleIdx];
 }
 
 function getNoteMetaSnippet(note: Note): string {
+  if (contentWithoutTags(note.content) === "") return "No Content";
   const lines = note.content.split("\n");
-  if (!lines[0] || contentWithoutTags(note.content) === "") return "No Content";
-  const secondLine = lines.slice(1).find((l) => l.trim() !== "") ?? "";
-  return secondLine.length > 30 ? secondLine.slice(0, 30) + "…" : secondLine;
+  const titleIdx = firstNonBlankIndex(lines);
+  if (titleIdx === -1) return "No Content";
+  // Search below the title line, wherever that turned out to be.
+  const snippet = lines.slice(titleIdx + 1).find((l) => l.trim() !== "") ?? "";
+  return snippet.length > 30 ? snippet.slice(0, 30) + "…" : snippet;
 }
 
 function formatTimestamp(ts: number): string {


### PR DESCRIPTION
Closes #126.

## The bug

A note whose content opens with an empty line was listed as **"No Text Entered" / "No Content"** — the list claiming the note was empty while the content pane showed its text perfectly well.

```
(blank first line)
Buy milk
remember the oat one
```

## Cause

`getNoteTitle` took `content.split("\n")[0]` and relied on the empty string being falsy, so *"line 1 is blank"* and *"the note is empty"* were the same condition. `getNoteMetaSnippet` had the identical `!lines[0]` guard.

Both now find the first line with something on it: the title is that line, and the snippet is the next non-blank line **below it** (rather than blindly line 2, which would be wrong once the title has moved down).

## A second case in the same expression

A first line of only spaces or tabs is a **non-empty string**, so it was accepted as the title and the entry rendered **blank** — no text and no placeholder either. Blank now means "nothing but whitespace", so such a note reports `No Text Entered` like any other empty one.

## Unchanged on purpose

- An untouched new note still shows `New Note`.
- A note that is only `#tags` still takes its tag line as the title with `No Content` beneath — a tag line is real text.
- `No Text Entered` / `No Content` are now reserved for notes that genuinely hold no text.

## MCP server too

`mcp/index.ts` carried the same defect in `noteTitle()` and in the archive confirmation, so `list_notes` and `search_notes` misreported exactly the same notes. Fixed alongside, since spec.md requires MCP output to stay consistent with the app.

## Tests

**12 e2e**: one and several leading blank lines, whitespace- and tab-only first lines, snippet selection below the title, blank lines between title and body, all-blank and whitespace-only notes, searchability of a blank-led note, and the tag-only and ordinary cases that must not change.

**9 of the 12 fail on the pre-fix code**; the 3 that pass are the unchanged-behaviour guards, which is what makes them worth keeping.

**216/216 `chromium`.**

## Notes for the reviewer

- `mcp/` reports 12 TypeScript errors locally, but `mcp/node_modules` is simply not installed — `origin/main` reports the identical 12. Nothing added by this change.
- The `firebase-roundtrip` file remains **flaky on `main`, independently of this change**: 13/14 here, with `cross-session sync` failing in the full-file run and passing 4/4 in isolation. I measured `origin/main` failing 1–2 tests on each of 3 consecutive runs. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)