### PR TITLE
Point the donate shortcut at notedude.app#donate

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -852,23 +852,26 @@ test.describe("Tag Search Keyboard Shortcuts", () => {
 });
 
 test.describe("Donate Shortcut", () => {
-  test("pressing 'd' twice opens donate URL in a new tab", async ({ page, context }) => {
-    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
-    let openedUrl = "";
-    await context.route("**/*", (route) => {
-      if (route.request().url() === "https://notedude.app/donate") {
-        openedUrl = route.request().url();
-        route.abort();
-      } else {
-        route.continue();
-      }
+  test("pressing 'd' twice opens the donate URL in a new tab", async ({ page }) => {
+    // Asserts what the app asks to open, not the resulting request. The donate target is a
+    // fragment, and fragments are client-side only — they are never sent to the server, so
+    // intercepting the network could only ever see "https://notedude.app/" (#129).
+    await page.addInitScript(() => {
+      (window as unknown as { __opened: string[] }).__opened = [];
+      window.open = (url?: string | URL) => {
+        (window as unknown as { __opened: string[] }).__opened.push(String(url));
+        return null;
+      };
     });
-    const newTabPromise = context.waitForEvent("page");
+    await page.reload();
+    await expect(page.getByTestId("app")).toHaveAttribute("data-state", "idle");
+    await page.getByTestId("app").focus();
+
     await page.keyboard.press("d");
     await page.keyboard.press("d");
-    await newTabPromise;
-    await page.waitForTimeout(500);
-    expect(openedUrl).toBe("https://notedude.app/donate");
+
+    const opened = await page.evaluate(() => (window as unknown as { __opened: string[] }).__opened);
+    expect(opened).toEqual(["https://notedude.app#donate"]);
   });
 
   test("pressing 'd' once does not open a tab", async ({ page, context }) => {

--- a/spec.md
+++ b/spec.md
@@ -138,7 +138,7 @@ SS → 'Esc Esc'              → IS    (message filter cleared)
 | `Shift+P`        | IS         | Toggle tag-pin on selected note (search-mode top when first tag matches) |
 | `?`              | IS         | Show keyboard shortcuts help overlay                        |
 | `⌘/` / `Ctrl+/`  | IS/ES/SS   | Show keyboard shortcuts help overlay (works from any state)  |
-| `d` then `d`     | IS         | Open `https://notedude.app/donate` in a new browser tab    |
+| `d` then `d`     | IS         | Open `https://notedude.app#donate` in a new browser tab    |
 | `r` then `r`     | IS         | Open `mailto:issues20260531@notedude.app` to report an issue |
 | `d` then `m`     | IS         | Toggle dark/light mode                                      |
 | `l` then `l`     | IS         | Log out the current user                                    |

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -840,7 +840,7 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
           if (dPrefixTimer.current) { clearTimeout(dPrefixTimer.current); dPrefixTimer.current = null; }
           if (e.key === "d") {
             e.preventDefault();
-            window.open("https://notedude.app/donate", "_blank");
+            window.open("https://notedude.app#donate", "_blank");
           } else if (e.key === "m") {
             e.preventDefault();
             setDarkMode((prev) => {


### PR DESCRIPTION
Closes #129.

`d` → `d` opened `https://notedude.app/donate`; it now opens **`https://notedude.app#donate`**.

## The test needed a new mechanism, not just a new string

The existing test matched on the **HTTP request URL**:

```ts
await context.route("**/*", (route) => {
  if (route.request().url() === "https://notedude.app/donate") { ... }
});
```

Fragments are client-side only and never reach the server, so a request for the new target arrives as `https://notedude.app/` — that interception could not match it however the expected string was written. Swapping the string alone would have produced a test that fails for the wrong reason.

It now stubs `window.open` and asserts the argument. That is what the app actually controls, it captures the fragment, and it drops the dependency on a real navigation happening at all.

Verified it fails on the pre-fix code (capturing the old `/donate` URL) and passes after.

## Tests

**203/204 `chromium`** — the one failure is `Save flash indicator › selected note row flashes on Escape save`, which passes **8/8** in isolation.

## Note for the reviewer

The `chromium` suite is **flaky on `main`**, independently of this change. Two consecutive full runs of `origin/main`: the first was clean at 204/204, the second failed `Dark Mode › theme preference persists across page reloads via localStorage` — a **different** test from the one that failed on this branch, and one this change cannot plausibly touch. Both are timing-sensitive and both pass in isolation.

That is the same pattern as #128, which I filed for the `firebase-roundtrip` project; this shows the `chromium` project has it too, so #128 should probably be widened. Worth fixing on its own — right now a full green run is not reliably reproducible on any branch, which makes "all tests pass" hard to hold anyone to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)