### PR TITLE
Restore popup sign-in for the installed desktop PWA (#132)

### DIFF
--- a/e2e/sign-in-flow.spec.ts
+++ b/e2e/sign-in-flow.spec.ts
@@ -155,3 +155,26 @@ test.describe("Sign-in flow selection", () => {
     ).toEqual({ openedPopup: false, redirected: true });
   });
 });
+
+test.describe("Sign-in failures are visible", () => {
+  test("a failed sign-in reports itself instead of silently returning to the login screen", async ({
+    page,
+  }) => {
+    // The #132 symptom was an invisible failure: errors were swallowed, so a broken
+    // sign-in was indistinguishable from a button that did nothing.
+    await page.route(/identitytoolkit|securetoken/, (route) => route.abort());
+    await page.route(/__\/auth\/|accounts\.google\.com/, (route) => route.abort());
+
+    await page.goto("/");
+    await expect(page.getByTestId("login-screen")).toBeVisible();
+    await page.getByRole("button", { name: /sign in with google/i }).click();
+
+    await expect(page.getByTestId("login-error")).toBeVisible();
+  });
+
+  test("no error is shown before a sign-in is attempted", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByTestId("login-screen")).toBeVisible();
+    await expect(page.getByTestId("login-error")).toHaveCount(0);
+  });
+});

--- a/e2e/sign-in-flow.spec.ts
+++ b/e2e/sign-in-flow.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect, Browser } from "@playwright/test";
+
+// Which sign-in flow each client gets (#132).
+//
+// The popup is correct for every client except an iOS home-screen app, where it opens in a
+// detached context that never returns a credential (#111). Routing *any* standalone client
+// to `signInWithRedirect` silently broke the installed desktop PWA: the Google account
+// chooser appeared, and choosing an account landed back on the login screen, signed out.
+//
+// These tests never complete a sign-in. They assert only the branch the app takes —
+// `window.open` for the popup, a top-level navigation to the auth handler for the redirect.
+// Both signals are recorded on the Node side, because the redirect branch tears down the
+// page's execution context on its way out.
+
+const DESKTOP_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36";
+const IPHONE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+
+type Client = {
+  /** `(display-mode: standalone)` — true for any installed PWA, desktop included. */
+  standalone: boolean;
+  /** `navigator.standalone`, which only iOS/iPadOS Safari defines. */
+  iosStandalone?: boolean;
+  /** `(pointer: coarse)` — the *primary* pointer, so a touch laptop is still false. */
+  coarse?: boolean;
+  /** iPadOS reports a Mac user-agent; touch points are what give it away. */
+  touchPoints?: number;
+};
+
+/**
+ * Open a page impersonating a client's install/input signals, and report which sign-in
+ * branch it takes. Firebase validates the origin against the project config before it opens
+ * anything, so that call is answered locally; every real auth navigation is aborted, which
+ * still lets us observe that it was attempted.
+ */
+async function signInBranch(browser: Browser, userAgent: string, client: Client) {
+  const context = await browser.newContext({ userAgent });
+  const popups: string[] = [];
+  const redirects: string[] = [];
+
+  await context.exposeFunction("__reportPopup", (url: string) => {
+    popups.push(url);
+  });
+
+  await context.addInitScript((c: Client) => {
+    const real = window.matchMedia.bind(window);
+    const mql = (media: string, matches: boolean) =>
+      ({
+        media,
+        matches,
+        onchange: null,
+        addListener() {},
+        removeListener() {},
+        addEventListener() {},
+        removeEventListener() {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList;
+
+    window.matchMedia = (q: string) =>
+      q.includes("display-mode: standalone")
+        ? mql(q, c.standalone)
+        : q.includes("pointer: coarse")
+          ? mql(q, !!c.coarse)
+          : real(q);
+
+    if (c.iosStandalone) {
+      Object.defineProperty(navigator, "standalone", { get: () => true, configurable: true });
+    }
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      get: () => c.touchPoints ?? 0,
+      configurable: true,
+    });
+
+    // Record the popup attempt instead of really opening a window.
+    window.open = ((url?: string | URL) => {
+      (window as unknown as { __reportPopup: (u: string) => void }).__reportPopup(
+        String(url ?? "")
+      );
+      return { closed: false, close() {}, focus() {} };
+    }) as typeof window.open;
+  }, client);
+
+  const page = await context.newPage();
+  page.on("request", (r) => {
+    if (r.isNavigationRequest() && r.frame() === page.mainFrame() && /__\/auth\/handler/.test(r.url())) {
+      redirects.push(r.url());
+    }
+  });
+
+  await page.route(/identitytoolkit|securetoken/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        projectId: "notedude2",
+        authorizedDomains: ["localhost", "127.0.0.1", "notedude2.web.app"],
+      }),
+    })
+  );
+  await page.route(/__\/auth\/|emulator\/auth\/|accounts\.google\.com/, (route) => route.abort());
+
+  await page.goto("/");
+  await expect(page.getByTestId("login-screen")).toBeVisible();
+  await page.getByRole("button", { name: /sign in with google/i }).click();
+
+  await expect
+    .poll(() => popups.length > 0 || redirects.length > 0, { timeout: 10_000 })
+    .toBe(true);
+
+  const branch = { openedPopup: popups.length > 0, redirected: redirects.length > 0 };
+  await context.close();
+  return branch;
+}
+
+test.describe("Sign-in flow selection", () => {
+  test("installed desktop PWA uses the popup, not a redirect", async ({ browser }) => {
+    // The #132 regression: standalone display mode alone used to force the redirect.
+    expect(await signInBranch(browser, DESKTOP_UA, { standalone: true })).toEqual({
+      openedPopup: true,
+      redirected: false,
+    });
+  });
+
+  test("ordinary desktop browser uses the popup", async ({ browser }) => {
+    expect(await signInBranch(browser, DESKTOP_UA, { standalone: false })).toEqual({
+      openedPopup: true,
+      redirected: false,
+    });
+  });
+
+  test("touch device in a browser tab uses the popup", async ({ browser }) => {
+    // A coarse pointer on its own is not a reason to redirect; only an installed iOS app is.
+    expect(
+      await signInBranch(browser, IPHONE_UA, { standalone: false, coarse: true, touchPoints: 5 })
+    ).toEqual({ openedPopup: true, redirected: false });
+  });
+
+  test("iOS home-screen app uses the redirect", async ({ browser }) => {
+    expect(
+      await signInBranch(browser, IPHONE_UA, {
+        standalone: true,
+        iosStandalone: true,
+        coarse: true,
+        touchPoints: 5,
+      })
+    ).toEqual({ openedPopup: false, redirected: true });
+  });
+
+  test("iPadOS home-screen app uses the redirect despite its Mac user-agent", async ({
+    browser,
+  }) => {
+    expect(
+      await signInBranch(browser, DESKTOP_UA, { standalone: true, coarse: true, touchPoints: 5 })
+    ).toEqual({ openedPopup: false, redirected: true });
+  });
+});

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/spec.md
+++ b/spec.md
@@ -34,9 +34,19 @@ Unlike a note created with `c`, a shared note is **written immediately** and is 
 
 If no user is signed in when the share arrives, the payload stays parked and is claimed after sign-in.
 
-### Sign-in on mobile
+### Sign-in: popup vs redirect
 
-`signInWithPopup` cannot reliably hand a credential back to an installed PWA — on iOS standalone the popup opens in a detached context that never returns. Clients in standalone display mode, or whose **primary** pointer is coarse, use `signInWithRedirect` instead; desktop browsers keep the popup, where it avoids a full page reload. The redirect result is claimed on mount before the auth listener is attached, so a returning user is not flashed the login screen.
+`signInWithPopup` is the flow for **every** client, including the installed desktop PWA.
+
+The sole exception is **iOS standalone** — a home-screen app on iOS or iPadOS — where a popup opens in a detached context that never returns a credential (#111). That client, and only that client, uses `signInWithRedirect`. It is identified by an iOS user-agent (or an iPadOS one, which reports as a Mac and is disambiguated by `maxTouchPoints`) *combined with* standalone display mode; `navigator.standalone` is the iOS-only signal for the same thing.
+
+The rule is deliberately narrow because the broad version regressed the desktop PWA (#132). Routing *any* `display-mode: standalone` client — or any device whose **primary** pointer is coarse — to the redirect meant an installed desktop PWA took the redirect path, where the Google account chooser appeared and picking an account returned the user to the login screen, signed out and with no error.
+
+`signInWithRedirect` is unreliable on this deployment for **any** client. The app is served from `notedude2.web.app` / `app.notedude.app` while Firebase's `authDomain` is `notedude2.firebaseapp.com`, and the SDK hands the credential back by reading state through a hidden iframe at `https://<authDomain>/__/auth/iframe`. Chrome 115+ partitions third-party storage, so that iframe reads nothing and `getRedirectResult()` resolves empty. The real fix is a same-origin `authDomain`: Firebase Hosting already serves `/__/auth/handler` and `/__/auth/iframe` on every domain of the project (and exempts those reserved paths from the `X-Frame-Options: DENY` header `firebase.json` applies to `**`), but switching also requires registering `https://<host>/__/auth/handler` as an authorized OAuth redirect URI, which is a console change (#132).
+
+The redirect result is claimed on mount before the auth listener is attached, so a returning user is not flashed the login screen.
+
+A failed sign-in **shows an error on the login screen**. Failures used to be invisible: `auth/popup-closed-by-user` was discarded and every other error became an unhandled rejection, so a broken sign-in was indistinguishable from a no-op. Deliberately dismissing the popup is still silent — that is a user choice, not a failure.
 
 ### Install appearance
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ function useDarkMode(): boolean {
 }
 
 export default function Page() {
-  const { user, loading, login, logout } = useAuth();
+  const { user, loading, error, login, logout } = useAuth();
   const [demoMode, setDemoMode] = useState(false);
   const darkMode = useDarkMode();
 
@@ -92,6 +92,12 @@ export default function Page() {
         <button onClick={() => setDemoMode(true)} style={{ padding: "8px 16px", fontFamily: "inherit", fontSize: 14, cursor: "pointer", background: "none", border: `1px solid ${border}`, color: muted }}>
           <u>d</u>emo mode
         </button>
+        {/* A failed sign-in used to look identical to no sign-in at all (#132). */}
+        {error && (
+          <div data-testid="login-error" role="alert" style={{ fontSize: 12, maxWidth: 380, textAlign: "center", color: darkMode ? "#ff8a8a" : "#b00020" }}>
+            {error}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/lib/authStrategy.ts
+++ b/src/lib/authStrategy.ts
@@ -1,0 +1,50 @@
+/**
+ * Which Google sign-in flow a client should use.
+ *
+ * `signInWithPopup` is right for every client but one, and is the only flow that reliably
+ * completes on this deployment. The app is served from `notedude2.web.app` /
+ * `app.notedude.app` while Firebase's `authDomain` is `notedude2.firebaseapp.com`, so
+ * `signInWithRedirect` has to hand the credential back by reading state through a hidden
+ * iframe at `https://<authDomain>/__/auth/iframe` — a third origin. Chrome 115+ partitions
+ * third-party storage, so that iframe reads nothing, `getRedirectResult()` resolves empty,
+ * and the user lands back on the login screen signed out (#132).
+ *
+ * The exception is an iOS or iPadOS home-screen app, where a popup opens in a detached
+ * context that never returns a credential at all (#111). Redirect is the only flow available
+ * there, cross-origin `authDomain` notwithstanding.
+ *
+ * An earlier version of this rule sent *any* standalone client — and any device with a
+ * coarse primary pointer — down the redirect path, which is what broke sign-in in the
+ * installed **desktop** PWA. Desktop PWAs open popups perfectly well; only iOS cannot.
+ */
+export function prefersRedirect(win: Window | undefined = globalThis.window): boolean {
+  if (!win) return false;
+
+  const nav = win.navigator as Navigator & { standalone?: boolean };
+  const ua = nav.userAgent;
+
+  // iPadOS reports a Mac user-agent, so multi-touch is what separates it from a desktop.
+  const isIOS = /iPad|iPhone|iPod/.test(ua) || (/Macintosh/.test(ua) && nav.maxTouchPoints > 1);
+
+  // `navigator.standalone` is the iOS-only spelling of the same thing; it predates
+  // `display-mode` and is still the reliable signal on older iOS Safari.
+  const isStandalone =
+    !!win.matchMedia?.("(display-mode: standalone)").matches || nav.standalone === true;
+
+  return isIOS && isStandalone;
+}
+
+/** A short, lowercase explanation for the login screen. */
+export function describeAuthError(e: unknown): string {
+  const code = (e as { code?: string } | null)?.code ?? "";
+  switch (code) {
+    case "auth/popup-blocked":
+      return "your browser blocked the sign-in window — allow popups for this site and try again.";
+    case "auth/network-request-failed":
+      return "couldn't reach google. check your connection and try again.";
+    case "auth/unauthorized-domain":
+      return "this domain isn't authorized for sign-in.";
+    default:
+      return `sign-in failed${code ? ` (${code})` : ""}. please try again.`;
+  }
+}

--- a/src/lib/useAuth.ts
+++ b/src/lib/useAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   onAuthStateChanged,
   signInWithPopup,
@@ -8,47 +8,49 @@ import {
   User,
 } from "firebase/auth";
 import { auth, googleProvider } from "./firebase";
+import { prefersRedirect, describeAuthError } from "./authStrategy";
 
-/**
- * A popup cannot reliably hand the credential back to an installed PWA: on iOS standalone
- * it opens in a detached context that never returns, leaving sign-in permanently stuck.
- * Those clients get a redirect instead. Desktop browsers keep the popup, where it is the
- * better UX and avoids a full page reload. See #111.
- */
-function prefersRedirect(): boolean {
-  if (typeof window === "undefined") return false;
-  const standalone =
-    window.matchMedia?.("(display-mode: standalone)").matches ||
-    // iOS Safari predates display-mode and reports installation this way instead.
-    (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
-  // `pointer: coarse` describes the *primary* input, so a touch-capable laptop driven by
-  // a mouse still counts as desktop and keeps the popup.
-  const touchFirst = window.matchMedia?.("(pointer: coarse)").matches;
-  return !!(standalone || touchFirst);
-}
+// Dismissing the popup, or superseding it with a second click, is a user's choice rather
+// than a failure — neither belongs on the login screen as an error.
+const CANCELLED = new Set(["auth/popup-closed-by-user", "auth/cancelled-popup-request"]);
 
 export function useAuth() {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     // Claim the credential left by a redirect sign-in. onAuthStateChanged alone would fire
     // with null first and flash the login screen at a user who just authenticated.
-    getRedirectResult(auth).catch((e) => console.error("Redirect sign-in failed:", e));
+    getRedirectResult(auth).catch((e) => {
+      console.error("Redirect sign-in failed:", e);
+      setError(describeAuthError(e));
+    });
     return onAuthStateChanged(auth, (u) => {
       setUser(u);
       setLoading(false);
     });
   }, []);
 
-  const login = () =>
-    prefersRedirect()
-      ? signInWithRedirect(auth, googleProvider)
-      : signInWithPopup(auth, googleProvider).catch((e) => {
-          if (e?.code !== "auth/popup-closed-by-user") throw e;
-        });
+  const login = useCallback(async () => {
+    setError(null);
+    try {
+      // See authStrategy.ts: the popup is the flow that works everywhere except an iOS
+      // home-screen app, where it opens detached and never returns (#111, #132).
+      if (prefersRedirect()) {
+        await signInWithRedirect(auth, googleProvider);
+      } else {
+        await signInWithPopup(auth, googleProvider);
+      }
+    } catch (e) {
+      if (CANCELLED.has((e as { code?: string } | null)?.code ?? "")) return;
+      // Swallowing this is what made #132 look like nothing had happened at all.
+      console.error("Sign-in failed:", e);
+      setError(describeAuthError(e));
+    }
+  }, []);
 
-  const logout = () => signOut(auth);
+  const logout = useCallback(() => signOut(auth), []);
 
-  return { user, loading, login, logout };
+  return { user, loading, error, login, logout };
 }


### PR DESCRIPTION
Closes #132.

## The bug

In the installed **desktop** PWA, clicking "sign in with google" showed the Google account chooser; picking an account returned to the login screen, signed out, with no error. A normal desktop browser tab was unaffected.

## Cause

`prefersRedirect()` (added in #111) routed **any** `display-mode: standalone` client — plus anything with a coarse primary pointer — to `signInWithRedirect`. An installed desktop PWA matches standalone, so it started taking the redirect path.

That path cannot complete on this deployment. The app is served from `notedude2.web.app` / `app.notedude.app` while `authDomain` is `notedude2.firebaseapp.com`; the SDK hands the credential back by reading state through a hidden iframe at `https://<authDomain>/__/auth/iframe`, a third origin. Chrome 115+ partitions third-party storage, so the iframe reads nothing and `getRedirectResult()` resolves empty.

Verified against production: the deployed bundle contains the `display-mode: standalone` branch, and ships `authDomain:"notedude2.firebaseapp.com"` while serving from `notedude2.web.app`.

**Why it surfaced on 2026-08-03 rather than on the #111 deploy (2026-07-29):** an installed PWA keeps serving its precached bundle until the waiting service worker activates, which for a window left open happens only after a full restart. The 2026-08-03 02:31 UTC deploy pushed a fresh worker through.

## Change

- Narrow the redirect to the client it was added for: an **iOS/iPadOS home-screen app**, where a popup opens detached and never returns a credential. Everything else — desktop PWA, desktop browser, mobile browser tab — keeps the popup. iPadOS is disambiguated from a desktop Mac by `maxTouchPoints`, since it reports a Mac user-agent.
- The rule moves to `src/lib/authStrategy.ts` with the reasoning next to it.
- **Stop swallowing sign-in failures.** `auth/popup-closed-by-user` was discarded and every other error became an unhandled rejection, which is why this looked like a no-op. Deliberate dismissal stays silent; anything else renders on the login screen.

## Tests

New `e2e/sign-in-flow.spec.ts` asserts the branch each client takes (`window.open` vs. a top-level navigation to the auth handler), without completing a sign-in and without live network. Both failing cases reproduce on `main` before the fix.

| client | flow |
| --- | --- |
| installed desktop PWA | popup ← **was redirect (the bug)** |
| ordinary desktop browser | popup |
| touch device, browser tab | popup ← was redirect |
| iOS home-screen app | redirect |
| iPadOS home-screen app (Mac UA) | redirect |

Full suite: 252 passed. `npm run build` clean.

## Known gap, not fixed here

`signInWithRedirect` remains broken for **iOS/Android installed PWAs** for the same third-party-storage reason — this PR just stops desktop from needing it. The real fix is a same-origin `authDomain`. Firebase Hosting already serves `/__/auth/handler` and `/__/auth/iframe` on every domain of the project, and exempts those reserved paths from the `X-Frame-Options: DENY` that `firebase.json` applies to `**` (both verified, 200 with no XFO header). Switching also requires registering the redirect URIs on the OAuth client, which is a console change I can't make:

- `https://notedude2.web.app/__/auth/handler`
- `https://app.notedude.app/__/auth/handler`

🤖 Generated with [Claude Code](https://claude.com/claude-code)