### PR TITLE
Google Tasks sync, phase 1: spec, rules and pure sync logic (#138)

### DIFF
--- a/e2e/gtasks-logic.spec.ts
+++ b/e2e/gtasks-logic.spec.ts
@@ -1,0 +1,363 @@
+/**
+ * Pure-logic tests for the Google Tasks sync (#138).
+ *
+ * These run in the Playwright suite but never touch a browser, Firestore, or the network —
+ * every module under test is free of side effects and of Firebase imports. The sync's hard
+ * parts are all decisions (which tag wins, which side is authoritative, whether a due date
+ * means "today"), so they are worth testing where they can be tested exhaustively and fast.
+ */
+import { test, expect } from "@playwright/test";
+
+import {
+  appendTag,
+  stripTag,
+  withTaskTag,
+  withoutTaskTag,
+  taskTagOf,
+  isArchivedContent,
+} from "../src/lib/tags";
+import {
+  listNameToTag,
+  tagToListName,
+  isSyncedListName,
+} from "../src/lib/gtasks/normalize";
+import {
+  localDateKey,
+  dueDateKey,
+  dueValueForLocalDate,
+  isDueOnOrBeforeToday,
+} from "../src/lib/gtasks/dates";
+import {
+  resolveTaskTag,
+  taskToNoteContent,
+  noteToTaskFields,
+  dueActionForTag,
+} from "../src/lib/gtasks/mapping";
+import {
+  noteSyncHash,
+  taskSyncHash,
+  decidePairAction,
+  mergeConflict,
+} from "../src/lib/gtasks/diff";
+import type { GTask } from "../src/lib/gtasks/types";
+
+// A Google task as the API returns it, with only the fields the sync reads.
+function task(over: Partial<GTask> = {}): GTask {
+  return { id: "t1", title: "Call the vet", status: "needsAction", ...over };
+}
+
+// Local-time construction: `new Date(y, mIndex, d)` is timezone-independent by definition,
+// which keeps these assertions honest regardless of where the suite runs.
+const AUG_4 = new Date(2026, 7, 4, 9, 0);
+const AUG_3 = new Date(2026, 7, 3, 9, 0);
+
+// ── Tag arithmetic ────────────────────────────────────────────────────────────────
+
+test.describe("tag arithmetic", () => {
+  test("appendTag adds a separating space, except on empty content", () => {
+    expect(appendTag("Call the vet", "#tasks-today")).toBe("Call the vet #tasks-today");
+    expect(appendTag("", "#tasks-today")).toBe("#tasks-today");
+    expect(appendTag("Line one\n", "#tasks-today")).toBe("Line one\n#tasks-today");
+  });
+
+  test("stripTag is the exact inverse of appendTag (#118)", () => {
+    for (const content of ["Call the vet", "", "Line one\n", "Multi\nline\nnote"]) {
+      expect(stripTag(appendTag(content, "#tasks-today"), "#tasks-today")).toBe(content);
+    }
+  });
+
+  test("withTaskTag replaces an existing task tag rather than appending a second", () => {
+    expect(withTaskTag("Call the vet #tasks-inbox", "#tasks-today")).toBe(
+      "Call the vet #tasks-today"
+    );
+    expect(withTaskTag("Call the vet", "#tasks-today")).toBe("Call the vet #tasks-today");
+  });
+
+  test("withTaskTag leaves non-task tags alone", () => {
+    expect(withTaskTag("Call the vet #work #tasks-inbox", "#tasks-today")).toBe(
+      "Call the vet #work #tasks-today"
+    );
+  });
+
+  test("taskTagOf reads the task tag, ignoring other tags", () => {
+    expect(taskTagOf("Call the vet #work #tasks-nearterm")).toBe("#tasks-nearterm");
+    expect(taskTagOf("Call the vet #work")).toBeNull();
+  });
+
+  test("withoutTaskTag removes the task tag and its separator", () => {
+    expect(withoutTaskTag("Call the vet #tasks-today")).toBe("Call the vet");
+    expect(withoutTaskTag("Call the vet")).toBe("Call the vet");
+  });
+
+  test("isArchivedContent detects the archive tag on a word boundary only", () => {
+    expect(isArchivedContent("Note #archived")).toBe(true);
+    expect(isArchivedContent("Note #archived-thoughts")).toBe(false);
+    expect(isArchivedContent("Note")).toBe(false);
+  });
+});
+
+// ── List ↔ tag naming ─────────────────────────────────────────────────────────────
+
+test.describe("list name normalization", () => {
+  test("lower-cases and replaces spaces with dashes", () => {
+    expect(listNameToTag("Tasks Longterm")).toBe("tasks-longterm");
+    expect(listNameToTag("Tasks Nearterm")).toBe("tasks-nearterm");
+  });
+
+  test("a name already in tag form passes through unchanged", () => {
+    expect(listNameToTag("tasks-nearterm")).toBe("tasks-nearterm");
+  });
+
+  test("drops punctuation and collapses repeated separators", () => {
+    expect(listNameToTag("Tasks: Today")).toBe("tasks-today");
+    expect(listNameToTag("Tasks  Longterm")).toBe("tasks-longterm");
+    expect(listNameToTag("Tasks - Longterm")).toBe("tasks-longterm");
+    expect(listNameToTag("  Tasks Today  ")).toBe("tasks-today");
+  });
+
+  test("only tasks-* lists are in scope", () => {
+    expect(isSyncedListName("Tasks Today")).toBe(true);
+    expect(isSyncedListName("Groceries")).toBe(false);
+    // Bare "Tasks" yields "tasks", which has no suffix and is not a task tag.
+    expect(isSyncedListName("Tasks")).toBe(false);
+  });
+
+  test("tagToListName title-cases for list creation, and round-trips", () => {
+    expect(tagToListName("tasks-longterm")).toBe("Tasks Longterm");
+    for (const tag of ["tasks-inbox", "tasks-today", "tasks-nearterm", "tasks-longterm"]) {
+      expect(listNameToTag(tagToListName(tag))).toBe(tag);
+    }
+  });
+});
+
+// ── Dates ─────────────────────────────────────────────────────────────────────────
+
+test.describe("due dates", () => {
+  test("localDateKey reads local calendar parts", () => {
+    expect(localDateKey(new Date(2026, 7, 4, 13, 45))).toBe("2026-08-04");
+    expect(localDateKey(new Date(2026, 0, 9, 0, 5))).toBe("2026-01-09");
+  });
+
+  test("dueDateKey reads the UTC parts, because due is a calendar date at midnight UTC", () => {
+    expect(dueDateKey("2026-08-04T00:00:00.000Z")).toBe("2026-08-04");
+    expect(dueDateKey(null)).toBeNull();
+    expect(dueDateKey(undefined)).toBeNull();
+  });
+
+  test("dueValueForLocalDate encodes the local date as midnight UTC", () => {
+    // Late-evening local time must still produce that same local calendar date.
+    expect(dueValueForLocalDate(new Date(2026, 7, 4, 23, 30))).toBe("2026-08-04T00:00:00.000Z");
+  });
+
+  /**
+   * The off-by-one this guards: "2026-08-04T00:00:00Z" is 2026-08-03 17:00 local in UTC-7.
+   * Comparing instants would call it "yesterday" for every user west of UTC, so the
+   * comparison must be on calendar-date strings.
+   */
+  test("a task due today counts as today regardless of local offset", () => {
+    expect(isDueOnOrBeforeToday("2026-08-04T00:00:00.000Z", AUG_4)).toBe(true);
+    expect(isDueOnOrBeforeToday("2026-08-04T00:00:00.000Z", AUG_3)).toBe(false);
+  });
+
+  test("overdue counts as today; future does not", () => {
+    expect(isDueOnOrBeforeToday("2026-08-01T00:00:00.000Z", AUG_4)).toBe(true);
+    expect(isDueOnOrBeforeToday("2026-08-05T00:00:00.000Z", AUG_4)).toBe(false);
+  });
+
+  test("no due date is never 'today'", () => {
+    expect(isDueOnOrBeforeToday(null, AUG_4)).toBe(false);
+  });
+});
+
+// ── Tag resolution ────────────────────────────────────────────────────────────────
+
+test.describe("resolveTaskTag precedence", () => {
+  test("a completed task is #tasks-done, outranking both due date and list", () => {
+    const t = task({ status: "completed", due: "2026-08-04T00:00:00.000Z" });
+    expect(resolveTaskTag(t, "tasks-nearterm", AUG_4)).toBe("#tasks-done");
+  });
+
+  /** The whole point of the due-date rule: Assistant sets due=today instead of the list. */
+  test("a task due today is #tasks-today even when it lives in another list", () => {
+    const t = task({ due: "2026-08-04T00:00:00.000Z" });
+    expect(resolveTaskTag(t, "tasks-nearterm", AUG_4)).toBe("#tasks-today");
+  });
+
+  test("an overdue task is #tasks-today", () => {
+    const t = task({ due: "2026-07-30T00:00:00.000Z" });
+    expect(resolveTaskTag(t, "tasks-longterm", AUG_4)).toBe("#tasks-today");
+  });
+
+  test("a task due later keeps its list's tag", () => {
+    const t = task({ due: "2026-09-01T00:00:00.000Z" });
+    expect(resolveTaskTag(t, "tasks-longterm", AUG_4)).toBe("#tasks-longterm");
+  });
+
+  test("a task with no due date keeps its list's tag", () => {
+    expect(resolveTaskTag(task(), "tasks-nearterm", AUG_4)).toBe("#tasks-nearterm");
+  });
+});
+
+// ── Field mapping ─────────────────────────────────────────────────────────────────
+
+test.describe("task ↔ note field mapping", () => {
+  test("a pulled task uses the house `Title #tag` convention", () => {
+    expect(taskToNoteContent(task(), "#tasks-nearterm")).toBe("Call the vet #tasks-nearterm");
+  });
+
+  test("task notes become the body, below the title line", () => {
+    const t = task({ notes: "Bring the carrier" });
+    expect(taskToNoteContent(t, "#tasks-nearterm")).toBe(
+      "Call the vet #tasks-nearterm\nBring the carrier"
+    );
+  });
+
+  test("an empty task title never yields a tag-only note, which the app would discard", () => {
+    expect(taskToNoteContent(task({ title: "" }), "#tasks-inbox")).toBe(
+      "Untitled task #tasks-inbox"
+    );
+  });
+
+  test("the pushed title drops the task tag, since the list encodes it", () => {
+    expect(noteToTaskFields("Call the vet #tasks-nearterm")).toEqual({
+      title: "Call the vet",
+      notes: "",
+    });
+  });
+
+  test("the pushed title preserves non-task tags, so nothing is lost", () => {
+    expect(noteToTaskFields("Call the vet #work #tasks-nearterm")).toEqual({
+      title: "Call the vet #work",
+      notes: "",
+    });
+  });
+
+  test("lines below the first become task notes verbatim", () => {
+    expect(noteToTaskFields("Call the vet #tasks-nearterm\nBring the carrier\nAsk about food")).toEqual({
+      title: "Call the vet",
+      notes: "Bring the carrier\nAsk about food",
+    });
+  });
+
+  test("pull then push round-trips without drift", () => {
+    const original = task({ notes: "Bring the carrier" });
+    const content = taskToNoteContent(original, "#tasks-nearterm");
+    expect(noteToTaskFields(content)).toEqual({
+      title: original.title,
+      notes: original.notes,
+    });
+  });
+});
+
+// ── Due-date push (the oscillation fix) ───────────────────────────────────────────
+
+test.describe("dueActionForTag", () => {
+  test("#tasks-today sets a due date of today", () => {
+    expect(dueActionForTag("#tasks-today", null, AUG_4)).toEqual({
+      kind: "set",
+      due: "2026-08-04T00:00:00.000Z",
+    });
+  });
+
+  test("#tasks-today with today's due date already set is left alone", () => {
+    expect(dueActionForTag("#tasks-today", "2026-08-04T00:00:00.000Z", AUG_4)).toEqual({
+      kind: "keep",
+    });
+  });
+
+  /**
+   * Without this, retagging a due-today task to #tasks-nearterm leaves due=today in place,
+   * and the very next pull resolves it back to #tasks-today — forever. See #138.
+   */
+  test("retagging away from today clears a due date that is on or before today", () => {
+    expect(dueActionForTag("#tasks-nearterm", "2026-08-04T00:00:00.000Z", AUG_4)).toEqual({
+      kind: "clear",
+    });
+    expect(dueActionForTag("#tasks-nearterm", "2026-07-28T00:00:00.000Z", AUG_4)).toEqual({
+      kind: "clear",
+    });
+  });
+
+  test("a future due date is never touched", () => {
+    expect(dueActionForTag("#tasks-nearterm", "2026-09-01T00:00:00.000Z", AUG_4)).toEqual({
+      kind: "keep",
+    });
+  });
+
+  test("a task with no due date and no today tag needs no change", () => {
+    expect(dueActionForTag("#tasks-nearterm", null, AUG_4)).toEqual({ kind: "keep" });
+  });
+
+  test("#tasks-done leaves the due date as it is", () => {
+    expect(dueActionForTag("#tasks-done", "2026-08-04T00:00:00.000Z", AUG_4)).toEqual({
+      kind: "keep",
+    });
+  });
+});
+
+// ── Change detection ──────────────────────────────────────────────────────────────
+
+test.describe("change detection", () => {
+  test("the note hash covers title, body and tag", () => {
+    const base = noteSyncHash("Call the vet #tasks-nearterm");
+    expect(noteSyncHash("Call the vet #tasks-nearterm")).toBe(base);
+    expect(noteSyncHash("Call the dentist #tasks-nearterm")).not.toBe(base);
+    expect(noteSyncHash("Call the vet #tasks-today")).not.toBe(base);
+    expect(noteSyncHash("Call the vet #tasks-nearterm\nBring carrier")).not.toBe(base);
+  });
+
+  test("the task hash covers title, notes, status and due", () => {
+    const base = taskSyncHash(task());
+    expect(taskSyncHash(task())).toBe(base);
+    expect(taskSyncHash(task({ title: "Call the dentist" }))).not.toBe(base);
+    expect(taskSyncHash(task({ status: "completed" }))).not.toBe(base);
+    expect(taskSyncHash(task({ due: "2026-08-04T00:00:00.000Z" }))).not.toBe(base);
+    expect(taskSyncHash(task({ notes: "Bring carrier" }))).not.toBe(base);
+  });
+
+  const link = { taskId: "t1", listId: "l1", noteHash: "N", taskHash: "T", lastSyncedAt: 0 };
+
+  test("neither side moved → nothing to do", () => {
+    expect(
+      decidePairAction({ link, noteHash: "N", taskHash: "T", noteUpdatedAt: 1, taskUpdatedAt: 1 })
+    ).toEqual({ kind: "noop" });
+  });
+
+  test("only the note moved → push", () => {
+    expect(
+      decidePairAction({ link, noteHash: "N2", taskHash: "T", noteUpdatedAt: 2, taskUpdatedAt: 1 })
+    ).toEqual({ kind: "push" });
+  });
+
+  test("only the task moved → pull", () => {
+    expect(
+      decidePairAction({ link, noteHash: "N", taskHash: "T2", noteUpdatedAt: 1, taskUpdatedAt: 2 })
+    ).toEqual({ kind: "pull" });
+  });
+
+  test("both moved → conflict, resolved last-write-wins", () => {
+    expect(
+      decidePairAction({ link, noteHash: "N2", taskHash: "T2", noteUpdatedAt: 5, taskUpdatedAt: 2 })
+    ).toEqual({ kind: "conflict", winner: "note" });
+    expect(
+      decidePairAction({ link, noteHash: "N2", taskHash: "T2", noteUpdatedAt: 2, taskUpdatedAt: 5 })
+    ).toEqual({ kind: "conflict", winner: "task" });
+  });
+});
+
+// ── Conflict merge ────────────────────────────────────────────────────────────────
+
+test.describe("conflict merge", () => {
+  test("the losing text is preserved under a #sync-conflict marker, never dropped", () => {
+    const merged = mergeConflict("Call the vet #tasks-today", "Call the dentist");
+    expect(merged).toContain("Call the vet #tasks-today");
+    expect(merged).toContain("#sync-conflict");
+    expect(merged).toContain("Call the dentist");
+  });
+
+  test("identical text on both sides needs no conflict block", () => {
+    expect(mergeConflict("Call the vet #tasks-today", "Call the vet")).toBe(
+      "Call the vet #tasks-today"
+    );
+  });
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -19,9 +19,26 @@ service cloud.firestore {
         && (data.updatedAt is timestamp || data.updatedAt is number);
     }
 
+    // A Google Tasks link record (#138): which task a note is synced to, and the hashes of
+    // both sides at the last successful sync. Kept out of the note document because the note
+    // schema above is closed, and that document is the one protected against lost updates.
+    function isValidGTaskLink(data) {
+      return data.keys().hasOnly(['taskId', 'listId', 'noteHash', 'taskHash', 'lastSyncedAt'])
+        && data.taskId is string
+        && data.listId is string
+        && data.noteHash is string
+        && data.taskHash is string
+        && (data.lastSyncedAt is timestamp || data.lastSyncedAt is number);
+    }
+
     match /users/{userId}/notes/{noteId} {
       allow read, delete: if isOwner(userId);
       allow create, update: if isOwner(userId) && isValidNote(request.resource.data);
+    }
+
+    match /users/{userId}/gtasks/{noteId} {
+      allow read, delete: if isOwner(userId);
+      allow create, update: if isOwner(userId) && isValidGTaskLink(request.resource.data);
     }
   }
 }

--- a/spec.md
+++ b/spec.md
@@ -585,6 +585,89 @@ Validated like notes: only `taskId`, `listId`, `noteHash`, `taskHash`, `lastSync
 
 > **Deploy note:** `npm run deploy` publishes **hosting only**. This rules change requires `firebase deploy --only firestore:rules`, or the sync fails in production with `permission-denied` while working fine against the emulator.
 
+### Authorization
+
+The Tasks scope is obtained through **Google Identity Services**, as an authorization layer alongside Firebase authentication rather than through it.
+
+Requesting `auth/tasks` on the Firebase Google provider is the obvious shortcut and does not work. Firebase surfaces the provider's OAuth access token only at the moment of sign-in, it expires in about an hour, and Firebase offers no way to refresh it. The Firebase session then stays valid for weeks while the Tasks token is long dead — the sync works immediately after login and silently stops thereafter.
+
+```
+google.accounts.oauth2.initTokenClient({ client_id, scope, callback })
+tokenClient.requestAccessToken({ prompt: "" })   // "" = silent when already granted
+```
+
+The browser flow issues **no refresh token**, by design. `prompt: ""` re-issues silently when the user has both a prior grant and a live Google session, which covers the common case — but it depends on Google's session cookies, so it degrades under Safari's ITP and third-party-cookie restrictions, and a request made without a user gesture can be popup-blocked.
+
+Silent re-issue is therefore treated as best-effort, not as the happy path:
+
+- The access token is held **in memory only** — never `localStorage`, never anywhere the service worker can cache it
+- On `401` or a failed silent request, the sync stops and surfaces a visible **Reconnect Google Tasks** action rather than retrying in a loop
+- Nothing is lost by stopping: the plan is recomputed from scratch on the next run
+
+Setup: a **Web OAuth client** in the `notedude2` project with the app's origins listed under *Authorized JavaScript origins*, and the **Tasks API** enabled. `auth/tasks` is a sensitive scope; keeping the consent screen in Testing mode with the owner as a test user avoids Google's verification review. Testing mode's 7-day refresh-token expiry does not apply, as this flow issues none.
+
+### Tasks API access
+
+A thin typed `fetch` wrapper over `https://tasks.googleapis.com/tasks/v1` — not the `googleapis` package, which is Node-oriented and would bloat a static-export bundle. Four calls: list task lists, list tasks, insert task, patch task.
+
+Four properties of the API shape the client:
+
+- **Completed tasks are hidden by default.** `tasks.list` requires `showCompleted=true` **and** `showHidden=true`. Without the second, `#tasks-done` silently never populates, which presents as a mapping bug rather than a query-parameter one
+- **There is no sync token.** Incremental pulls use `updatedMin` together with `showDeleted=true` — the latter being how a task deleted in Google is detected, and therefore how its note comes to be archived (see **Completion and archiving**). The watermark is the **maximum `updated` value the server returned**, never the local clock at fetch time; clock skew would otherwise open a gap of permanently unread tasks. First run is a full pull
+- **Pagination is mandatory.** `maxResults` caps near 100, so `nextPageToken` looping is required, not an optimization
+- **Backoff, not batching.** No batch endpoint is assumed. Concurrency is capped at a few requests in flight, with exponential backoff and jitter on `429` and `5xx`
+
+Conditional writes (`ETag` / `If-Match`) are deliberately **not** used. The link record's `noteHash` / `taskHash` already provide a three-way-merge base — strictly more information than an ETag, and with no dependency on optional API behaviour.
+
+### Sync pipeline
+
+```
+auth.ts     → access token
+client.ts   → GTask[] / GTaskList[]
+links.ts    → SyncLink records
+              ↓
+plan.ts     → SyncPlan          (pure: notes + tasks + links → ops)
+              ↓
+execute.ts  → the only module that writes
+sync.ts     → orchestration, triggers, mode
+```
+
+`plan.ts` is pure and produces a list of operations:
+
+```ts
+type SyncOp =
+  | { kind: "createTask";  listId; noteId; fields }
+  | { kind: "patchTask";   listId; taskId; noteId; fields; due: DueAction }
+  | { kind: "createNote";  content; taskId; listId }
+  | { kind: "updateNote";  noteId; content }
+  | { kind: "createList";  title; tag }
+  | { kind: "deleteTask";  listId; taskId; noteId }
+  | { kind: "archiveNote"; noteId }
+  | { kind: "writeLink" | "deleteLink"; noteId; link? }
+```
+
+Two constraints on `execute.ts`:
+
+- Note writes go through the **same guarded update path the app uses**, never a raw `setDoc`. #74 is an open lost-update bug and a background writer is exactly what would trigger it
+- `plan.ts` takes a `NoteRepo` interface rather than importing Firestore, so the planner stays testable in-process against an in-memory fake
+
 ### Rollout
 
-The sync is gated behind `NEXT_PUBLIC_GTASKS_SYNC` and supports a **dry-run** mode that logs the operations it would perform without writing to either side. Existing task notes are backfilled to Google Tasks as an explicit one-time action after a dry run, never automatically on first load.
+The sync is gated at **two levels**, because `NEXT_PUBLIC_*` values are inlined at build time and this app is a static export: a build-time flag alone could only be changed by a rebuild and redeploy, against a service worker configured with `aggressiveFrontEndNavCaching` that may keep serving the previous bundle (see **Deployment model**).
+
+| Level | Control | Purpose |
+|---|---|---|
+| Build | `NEXT_PUBLIC_GTASKS_SYNC` | Off by default. When off the module is never imported, so it tree-shakes out and neither the GIS script nor the sync code reaches the bundle |
+| Runtime | Per-user mode `off` \| `dry-run` \| `live` | The actual switch. Takes effect on next load with no rebuild — the kill switch that matters the first time a live run misbehaves |
+
+**Dry-run is the absence of the final step, not a parallel mode.** The pipeline runs in full — authorize, fetch, normalize, map, diff, resolve conflicts — and the resulting `SyncPlan` is rendered as text instead of being handed to `execute.ts`. There is no second code path to drift, and no `if (dryRun)` branch inside the write logic where one missed case writes for real.
+
+One limitation is inherent: when a plan cascades — create a list, create tasks in it, write links to the returned IDs — a dry-run cannot show IDs that do not yet exist. Those render symbolically (`createTask → <new list "Tasks Longterm">`). Counts, titles and directions are accurate; identifiers are not.
+
+Existing task notes are backfilled to Google Tasks as an explicit one-time action after a dry run has been reviewed, never automatically on first load.
+
+### Testing
+
+- Playwright `route()` interception of `tasks.googleapis.com/**` provides a scripted Google; no real OAuth runs in CI and no headed browser is required
+- The token provider is faked under test, following the existing `NEXT_PUBLIC_SKIP_AUTH` precedent (see **Authentication bypass guard**)
+- `plan.ts` and the phase 1 modules are tested as pure functions, with no browser, Firestore or network

--- a/spec.md
+++ b/spec.md
@@ -477,3 +477,114 @@ Firebase Hosting serves these response headers on all routes (configured in `fir
 
 ### MCP archive consistency
 - The MCP `delete_note` tool performs a **soft archive** consistent with the app: it appends a `#archived` tag to the note's content (matching `Shift+Y`), rather than setting a separate field. This ensures notes archived via MCP are hidden in the app's Idle State exactly like notes archived in-app. It is idempotent — a note already tagged `#archived` is left unchanged.
+
+## Google Tasks Sync
+
+notedude's task notes stay in two-way sync with Google Tasks. The driving use case is voice capture: Gemini Assistant on a phone cannot reliably file a spoken task to a chosen list, so tasks land wherever it defaults and are re-filed later inside notedude. See #138.
+
+Non-task notes are out of scope here — they sync with Google Keep, specified separately.
+
+### Scope boundary
+
+A Google task list participates in the sync when its **normalized name** begins with `tasks-`; a note participates when its content carries a `#tasks-*` tag. Everything else — a `Groceries` list, a plain note — is invisible to the sync in both directions.
+
+### Where the sync runs
+
+The sync runs **client-side, in the browser, while the app is open**. The app is a static export with no server runtime (see **Deployment model**), and the browser already holds the user's Google identity; the `https://www.googleapis.com/auth/tasks` scope is layered onto it via Google Identity Services and the access token is held in memory only, never persisted.
+
+This deliberately rules out a scheduled script or Cloud Function. Either would be a **second writer that bypasses the Firestore Security Rules**, and would require storing a long-lived Google refresh token. The latency that matters is "tasks are present when I open notedude", which sync-on-load delivers; a push from notedude reaches Google Tasks immediately, because the app is by definition open at the moment of the edit.
+
+### List ↔ tag naming
+
+A list name is normalized to a tag by lower-casing it, replacing runs of whitespace with a single `-`, and dropping any character outside `[\w-]`. A name already in that form passes through unchanged.
+
+| Google Tasks list | notedude tag |
+|-------------------|--------------|
+| `Tasks Longterm`  | `#tasks-longterm` |
+| `tasks-nearterm`  | `#tasks-nearterm` |
+| `Tasks: Today`    | `#tasks-today` |
+| `Groceries`       | _(not synced)_ |
+
+The inverse (used when a tag has no matching list yet) title-cases the dash-separated words: `tasks-longterm` → `Tasks Longterm`.
+
+### Task ↔ note field mapping
+
+| Google task field | Note content |
+|-------------------|--------------|
+| `title` | First line, with the `#tasks-*` tag removed — the list already encodes it. **Other tags are preserved**, so nothing is lost |
+| `notes` | Remaining lines, verbatim |
+| `status: completed` | `#tasks-done` |
+
+A task pulled into notedude is written in the house `Title #tag` convention (see **Composing a Note**), so a task `Call the vet` in `Tasks Nearterm` becomes the note `Call the vet #tasks-nearterm`. A task with an empty title becomes `Untitled task`, so the note is never tag-only — which the app would discard.
+
+### Due dates and `#tasks-today`
+
+Told "add X to tasks today", Gemini Assistant sets a **due date of today** rather than filing to the *Tasks Today* list. The due date therefore participates in tag resolution, with this precedence:
+
+1. Task is completed → `#tasks-done`
+2. Task is due **on or before today** → `#tasks-today`
+3. Otherwise → the tag derived from its list
+
+Overdue counts as today, so a task does not rot unseen in another list.
+
+The push direction **must mirror this**, or the two systems oscillate. The note's tag is authoritative:
+
+- Tagged `#tasks-today` → move the task to the *Tasks Today* list and set its due date to today
+- Retagged away from `#tasks-today` → move the task to the matching list, and **clear the due date only if it was on or before today**. A future due date is never touched
+
+Without the clearing step, retagging a due-today task to `#tasks-nearterm` would be pulled straight back to `#tasks-today` on the next sync, forever.
+
+Google Tasks stores `due` as a **calendar date** encoded as midnight UTC. Comparisons therefore read the UTC date parts of `due` and compare them against the **local** calendar date as `YYYY-MM-DD` strings. Comparing instants instead would be off by one day for every user west of UTC.
+
+### Completion and archiving
+
+- Tagging a note `#tasks-done` completes the Google task **in place** — it is not moved to a `Tasks Done` list, so completion uses Google's native semantics and reads correctly on a phone
+- Completing a task in Google Tasks retags its note `#tasks-done`
+- Archiving a note (`Shift+Y` / `#archived`) **deletes** its Google task, keeping the lists clean. The note survives in notedude, which is the system of record for text
+- A task deleted in Google Tasks **archives** its note rather than deleting it. Archiving is reversible (`z`) and the note stays visible at the end of the list. Leaving the note untouched instead would let the next push recreate the task, resurrecting it forever
+
+### Sync state
+
+Link records live in their own collection, one document per synced note:
+
+```
+users/{userId}/gtasks/{noteId} → { taskId, listId, noteHash, taskHash, lastSyncedAt }
+```
+
+They are deliberately **not** fields on the note document: the note schema is closed by the Security Rules, and that document is the one protected against lost updates (#74). Link records are disposable — if the collection is lost, the sync rebuilds it by matching titles within a list rather than duplicating every task.
+
+### Change detection and conflicts
+
+Each link stores a hash of the note's syncable projection (title, body, tag) and of the task's (title, notes, status, due). On each pass the current hashes are compared with the stored ones:
+
+| Note changed | Task changed | Action |
+|---|---|---|
+| no  | no  | nothing |
+| yes | no  | push to Google Tasks |
+| no  | yes | pull into notedude |
+| yes | yes | conflict |
+
+A conflict resolves **last-write-wins** on timestamp — but the losing side's text is never discarded. It is appended to the note under a `#sync-conflict` marker, so a divergence is visible and recoverable rather than silently dropped. This follows the same principle as #75 / #76: the sync must not be able to lose text the user wrote.
+
+### Triggers
+
+- On app load, once the Tasks scope is available
+- On tab focus, and every 60s while the tab is visible (paused when hidden)
+- Debounced shortly after an edit to a note carrying a `#tasks-*` tag
+- Manually via `g` → `s`
+
+### Security rules for link records
+
+```
+match /users/{userId}/gtasks/{noteId} {
+  allow read, write: if request.auth.uid == userId;
+}
+```
+
+Validated like notes: only `taskId`, `listId`, `noteHash`, `taskHash`, `lastSyncedAt` may be present.
+
+> **Deploy note:** `npm run deploy` publishes **hosting only**. This rules change requires `firebase deploy --only firestore:rules`, or the sync fails in production with `permission-denied` while working fine against the emulator.
+
+### Rollout
+
+The sync is gated behind `NEXT_PUBLIC_GTASKS_SYNC` and supports a **dry-run** mode that logs the operations it would perform without writing to either side. Existing task notes are backfilled to Google Tasks as an explicit one-time action after a dry run, never automatically on first load.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,6 +3,14 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { subscribeToNotes, saveNote, setNotePinned, setNoteTagPinned, setNoteContent, accountHasNotes, type NoteData } from "../lib/notes";
 import { takePendingShare } from "../lib/share";
+import {
+  TASK_TAG_RE,
+  isArchivedContent,
+  appendTag,
+  stripTag,
+  withTaskTag,
+  withoutTaskTag,
+} from "../lib/tags";
 
 interface Note {
   id: string;
@@ -123,38 +131,8 @@ function sortNotes(notes: Note[]): Note[] {
   });
 }
 
-const ARCHIVED_RE = /#archived(?=[\s,.]|$)/i;
 function isArchived(note: Note): boolean {
-  return ARCHIVED_RE.test(note.content);
-}
-
-const TASK_TAG_RE = /#tasks-[\w-]+/;
-
-// --- Tag arithmetic ---------------------------------------------------------------
-// Every tag-only content change goes through these, so that adding a tag and taking it
-// away again are exact inverses. Callers own the arithmetic and hand the finished string
-// to setNoteContent(), which writes it verbatim — see #118.
-
-function appendTag(content: string, tag: string): string {
-  const sep = content.endsWith("\n") || content === "" ? "" : " ";
-  return content + sep + tag;
-}
-
-// Removes a tag along with the single space appendTag put in front of it.
-function stripTag(content: string, tag: string): string {
-  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return content.replace(new RegExp(`[ \\t]?${escaped}(?=[\\s,.]|$)`, "i"), "");
-}
-
-// Puts `tag` on the note, replacing whatever #tasks-* tag it already carries. A note
-// belongs to exactly one task list.
-function withTaskTag(content: string, tag: string): string {
-  return TASK_TAG_RE.test(content) ? content.replace(TASK_TAG_RE, tag) : appendTag(content, tag);
-}
-
-function withoutTaskTag(content: string): string {
-  const current = content.match(TASK_TAG_RE)?.[0];
-  return current ? stripTag(content, current) : content;
+  return isArchivedContent(note.content);
 }
 
 /**

--- a/src/lib/gtasks/dates.ts
+++ b/src/lib/gtasks/dates.ts
@@ -1,0 +1,40 @@
+/**
+ * Due-date handling for the Google Tasks sync (#138).
+ *
+ * Google Tasks stores `due` as a **calendar date** encoded as midnight UTC — the time part
+ * carries no meaning. So a due date's day must be read from its **UTC** parts, while "today"
+ * comes from the user's **local** parts, and the two are compared as `YYYY-MM-DD` strings.
+ *
+ * Comparing instants instead would be off by one day for every user west of UTC: the value
+ * "2026-08-04T00:00:00Z" is 2026-08-03 17:00 local in UTC-7, so a task due today would read
+ * as due yesterday. Lexicographic order on `YYYY-MM-DD` is chronological order, which is what
+ * makes the string comparison sound.
+ */
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/** The local calendar date of an instant, as `YYYY-MM-DD`. */
+export function localDateKey(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** The calendar date a Google `due` value denotes, as `YYYY-MM-DD`, or null if unset. */
+export function dueDateKey(due: string | null | undefined): string | null {
+  if (!due) return null;
+  const d = new Date(due);
+  if (Number.isNaN(d.getTime())) return null;
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+}
+
+/** A Google `due` value denoting the local calendar date of `d`. */
+export function dueValueForLocalDate(d: Date): string {
+  return `${localDateKey(d)}T00:00:00.000Z`;
+}
+
+/** Whether a task is due today or overdue. An unset due date is never "today". */
+export function isDueOnOrBeforeToday(due: string | null | undefined, now: Date): boolean {
+  const key = dueDateKey(due);
+  return key !== null && key <= localDateKey(now);
+}

--- a/src/lib/gtasks/diff.ts
+++ b/src/lib/gtasks/diff.ts
@@ -1,0 +1,78 @@
+/**
+ * Change detection and conflict resolution for the Google Tasks sync (#138).
+ */
+import { taskTagOf } from "../tags";
+import { dueDateKey } from "./dates";
+import { noteToTaskFields } from "./mapping";
+import type { GTask, SyncLink } from "./types";
+
+export const CONFLICT_TAG = "#sync-conflict";
+
+/** FNV-1a. Not cryptographic — this only has to be stable, cheap and dependency-free. */
+function hash(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, "0");
+}
+
+/**
+ * Hashes only what crosses the boundary. Edits the sync cannot represent — a pin, a tag-pin —
+ * leave the hash alone and so do not provoke a pointless round trip.
+ */
+export function noteSyncHash(content: string): string {
+  const { title, notes } = noteToTaskFields(content);
+  return hash([title, notes, taskTagOf(content) ?? ""].join("\u0000"));
+}
+
+/** Due is hashed by calendar date, so a same-day time change is not a change. */
+export function taskSyncHash(task: GTask): string {
+  return hash(
+    [task.title ?? "", task.notes ?? "", task.status, dueDateKey(task.due) ?? ""].join("\u0000")
+  );
+}
+
+export type PairAction =
+  | { kind: "noop" }
+  | { kind: "push" }
+  | { kind: "pull" }
+  | { kind: "conflict"; winner: "note" | "task" };
+
+/**
+ * Which way a linked pair should move, by comparing both sides against the hashes stored at
+ * the last successful sync. A conflict resolves last-write-wins; the loser's text is not
+ * discarded but folded in by mergeConflict.
+ */
+export function decidePairAction(input: {
+  link: SyncLink;
+  noteHash: string;
+  taskHash: string;
+  noteUpdatedAt: number;
+  taskUpdatedAt: number;
+}): PairAction {
+  const noteMoved = input.noteHash !== input.link.noteHash;
+  const taskMoved = input.taskHash !== input.link.taskHash;
+
+  if (!noteMoved && !taskMoved) return { kind: "noop" };
+  if (noteMoved && !taskMoved) return { kind: "push" };
+  if (!noteMoved && taskMoved) return { kind: "pull" };
+
+  return {
+    kind: "conflict",
+    winner: input.noteUpdatedAt >= input.taskUpdatedAt ? "note" : "task",
+  };
+}
+
+/**
+ * Folds the losing side of a conflict into the winning note under a #sync-conflict marker.
+ *
+ * Last-write-wins alone would delete text the user wrote on the losing side. #75 and #76 are
+ * both open data-loss bugs; a sync that can silently drop a sentence would be a third.
+ */
+export function mergeConflict(winningContent: string, losingText: string): string {
+  const losing = losingText.trim();
+  if (!losing || winningContent.includes(losing)) return winningContent;
+  return `${winningContent}\n\n${CONFLICT_TAG}\n${losing}`;
+}

--- a/src/lib/gtasks/mapping.ts
+++ b/src/lib/gtasks/mapping.ts
@@ -1,0 +1,73 @@
+/**
+ * Field mapping between a Google task and a notedude note. See #138.
+ */
+import { withoutTaskTag } from "../tags";
+import { dueDateKey, dueValueForLocalDate, isDueOnOrBeforeToday, localDateKey } from "./dates";
+import type { GTask } from "./types";
+
+export const DONE_TAG = "#tasks-done";
+export const TODAY_TAG = "#tasks-today";
+
+/** A task with an empty title would otherwise yield a tag-only note, which the app discards. */
+export const UNTITLED = "Untitled task";
+
+/**
+ * Which tag a task should carry, in precedence order:
+ *
+ *   1. completed              → #tasks-done
+ *   2. due on or before today → #tasks-today
+ *   3. otherwise              → the tag derived from its list
+ *
+ * Rule 2 exists because Gemini Assistant, told "tasks today", sets a due date of today rather
+ * than filing to the Tasks Today list. Overdue counts as today so nothing rots unseen.
+ */
+export function resolveTaskTag(task: GTask, listTag: string, now: Date): string {
+  if (task.status === "completed") return DONE_TAG;
+  if (isDueOnOrBeforeToday(task.due, now)) return TODAY_TAG;
+  return `#${listTag}`;
+}
+
+/** A pulled task, written in the house `Title #tag` convention. */
+export function taskToNoteContent(task: GTask, tag: string): string {
+  const title = task.title.trim() || UNTITLED;
+  const body = task.notes?.trim() ? `\n${task.notes}` : "";
+  return `${title} ${tag}${body}`;
+}
+
+/**
+ * A note, projected onto the task fields. The task tag is dropped from the title because the
+ * list already encodes it; every other tag is preserved, so the projection loses nothing.
+ */
+export function noteToTaskFields(content: string): { title: string; notes: string } {
+  const lines = content.split("\n");
+  return {
+    title: withoutTaskTag(lines[0]).trim(),
+    notes: lines.slice(1).join("\n"),
+  };
+}
+
+export type DueAction = { kind: "set"; due: string } | { kind: "clear" } | { kind: "keep" };
+
+/**
+ * What to do with a task's due date when pushing the note's tag.
+ *
+ * The clearing branch is what stops the two systems oscillating. Retagging a due-today task to
+ * #tasks-nearterm has to remove the due date, or resolveTaskTag pulls it straight back to
+ * #tasks-today on the next pass, forever. Only a due date that would trigger that rule is
+ * cleared — a future due date is the user's and is never touched.
+ */
+export function dueActionForTag(
+  tag: string,
+  currentDue: string | null | undefined,
+  now: Date
+): DueAction {
+  if (tag === TODAY_TAG) {
+    return dueDateKey(currentDue) === localDateKey(now)
+      ? { kind: "keep" }
+      : { kind: "set", due: dueValueForLocalDate(now) };
+  }
+  // Completion outranks the due date in resolveTaskTag, so a done task cannot oscillate and
+  // its due date is left as the user set it.
+  if (tag === DONE_TAG) return { kind: "keep" };
+  return isDueOnOrBeforeToday(currentDue, now) ? { kind: "clear" } : { kind: "keep" };
+}

--- a/src/lib/gtasks/normalize.ts
+++ b/src/lib/gtasks/normalize.ts
@@ -1,0 +1,41 @@
+/**
+ * Google Tasks list name ↔ notedude tag. See #138.
+ *
+ * "Tasks Longterm" ↔ "tasks-longterm". A name already in tag form passes through unchanged,
+ * so a user is free to name their lists either way.
+ */
+
+export const SYNCED_TAG_PREFIX = "tasks-";
+
+/**
+ * Lower-case, whitespace runs to a single dash, drop anything outside `[\w-]`, collapse
+ * repeated dashes. The output must be matchable by TASK_TAG_RE, hence the character filter.
+ */
+export function listNameToTag(listName: string): string {
+  return listName
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^\w-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** Inverse, used when a tag has no list yet: "tasks-longterm" → "Tasks Longterm". */
+export function tagToListName(tag: string): string {
+  return tag
+    .replace(/^#/, "")
+    .split("-")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/**
+ * Whether a list is in scope for the sync. A bare "Tasks" normalizes to "tasks", which has no
+ * suffix and is not a task tag, so it stays out — as does "Groceries".
+ */
+export function isSyncedListName(listName: string): boolean {
+  const tag = listNameToTag(listName);
+  return tag.startsWith(SYNCED_TAG_PREFIX) && tag.length > SYNCED_TAG_PREFIX.length;
+}

--- a/src/lib/gtasks/types.ts
+++ b/src/lib/gtasks/types.ts
@@ -1,0 +1,30 @@
+/** Google Tasks API shapes, narrowed to the fields the sync reads. See #138. */
+
+export interface GTask {
+  id: string;
+  title: string;
+  notes?: string;
+  status: "needsAction" | "completed";
+  /**
+   * RFC3339, but Google Tasks treats this as a **calendar date**: the time part is always
+   * midnight UTC and is not meaningful. Read it with the UTC accessors — see dates.ts.
+   */
+  due?: string | null;
+  /** RFC3339 instant of the last change, used to break conflicts. */
+  updated?: string;
+  deleted?: boolean;
+}
+
+export interface GTaskList {
+  id: string;
+  title: string;
+}
+
+/** One link record: `users/{uid}/gtasks/{noteId}`. Disposable — rebuildable by title match. */
+export interface SyncLink {
+  taskId: string;
+  listId: string;
+  noteHash: string;
+  taskHash: string;
+  lastSyncedAt: number;
+}

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,46 @@
+/**
+ * Tag arithmetic on note content.
+ *
+ * Every tag-only content change goes through these, so that adding a tag and taking it away
+ * again are exact inverses. Callers own the arithmetic and hand the finished string to
+ * setNoteContent(), which writes it verbatim — see #118.
+ *
+ * These live here rather than inside App.tsx because the Google Tasks sync (#138) performs the
+ * same arithmetic. A second copy is precisely how add and remove stop being inverses.
+ */
+
+export const ARCHIVED_RE = /#archived(?=[\s,.]|$)/i;
+export const TASK_TAG_RE = /#tasks-[\w-]+/;
+
+export function isArchivedContent(content: string): boolean {
+  return ARCHIVED_RE.test(content);
+}
+
+export function appendTag(content: string, tag: string): string {
+  const sep = content.endsWith("\n") || content === "" ? "" : " ";
+  return content + sep + tag;
+}
+
+/** Removes a tag along with the single space appendTag put in front of it. */
+export function stripTag(content: string, tag: string): string {
+  const escaped = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return content.replace(new RegExp(`[ \\t]?${escaped}(?=[\\s,.]|$)`, "i"), "");
+}
+
+/**
+ * Puts `tag` on the note, replacing whatever #tasks-* tag it already carries. A note belongs
+ * to exactly one task list. Non-task tags are left untouched.
+ */
+export function withTaskTag(content: string, tag: string): string {
+  return TASK_TAG_RE.test(content) ? content.replace(TASK_TAG_RE, tag) : appendTag(content, tag);
+}
+
+/** The note's task tag (e.g. `#tasks-today`), or null if it carries none. */
+export function taskTagOf(content: string): string | null {
+  return content.match(TASK_TAG_RE)?.[0] ?? null;
+}
+
+export function withoutTaskTag(content: string): string {
+  const current = taskTagOf(content);
+  return current ? stripTag(content, current) : content;
+}


### PR DESCRIPTION
Phase 1 of two-way sync between `#tasks-*` notes and Google Tasks, **plus the phase 2 design specced ahead of implementation**. No network calls, no orchestration, and nothing wired into the app yet. Refs #138.

Two commits:
1. **Phase 1** — spec, Security Rules, pure logic, 44 tests
2. **Phase 2 design** — `spec.md` only, no code

## Why client-side

The sync runs in the browser while the app is open. notedude is a static export with no server runtime, and the browser already holds the user's Google identity, so the `auth/tasks` scope layers onto it with no service account and no stored refresh token. A scheduled script or Cloud Function would be a second writer bypassing the Firestore Security Rules.

## The due-date rule

Told "tasks today", Gemini Assistant sets a **due date of today** rather than filing to the *Tasks Today* list — which is what makes voice capture unreliable. So due dates participate in tag resolution:

1. completed → `#tasks-done`
2. due on or before today → `#tasks-today`
3. otherwise → the list's tag

The push direction **must mirror this**. Retagging away from `#tasks-today` clears a due date on or before today, or the next pull resolves it straight back, forever. A future due date is never touched. That oscillation has its own test.

`due` is a calendar date pinned to midnight UTC, so comparisons run on `YYYY-MM-DD` strings built from the **UTC** parts of `due` and the **local** parts of now. Comparing instants would read "due today" as yesterday for every user west of UTC.

## Shared tag arithmetic

`appendTag` / `stripTag` / `withTaskTag` move out of `App.tsx` into `src/lib/tags.ts`, and `App.tsx` imports them. The sync needs the same arithmetic, and a second copy is precisely how adding a tag and removing it stop being exact inverses (see #118).

## Conflicts

Last-write-wins on timestamp, but the losing side's text is folded into the note under a `#sync-conflict` marker rather than dropped. #75 and #76 are already open data-loss bugs; a sync that can silently lose a sentence would be a third.

## Link records

`users/{uid}/gtasks/{noteId}` → `{ taskId, listId, noteHash, taskHash, lastSyncedAt }`, with field validation matching the house style. Deliberately not fields on the note document: that schema is closed by the rules, and it is the document protected against lost updates (#74). Link records are disposable — rebuildable by title match.

## Phase 2 design (spec only, second commit)

- **Authorization via Google Identity Services, alongside Firebase auth rather than through it.** Requesting `auth/tasks` on the Firebase Google provider is the obvious shortcut and does not work — Firebase exposes the provider token only at sign-in, it expires in ~1h, and cannot be refreshed. The sync would work right after login and silently stop. The browser flow issues no refresh token by design; silent re-issue is best-effort (Safari ITP, popup blocking) with a visible **Reconnect** fallback, token in memory only.
- **REST client gotchas.** `showCompleted` needs `showHidden` alongside it or `#tasks-done` never populates. No sync token exists, so incremental pulls use `updatedMin` with the **server's** max `updated` as watermark, never the local clock. `showDeleted` is what surfaces a task deleted in Google — the mechanism behind the existing archive-the-note rule.
- **Pure `plan.ts` + write-only `execute.ts`.** This is what makes **dry-run the absence of the final step** rather than a parallel code path with its own bugs. Stated limitation: a dry-run cannot show IDs for cascading creates.
- **Two-level rollout gate.** `NEXT_PUBLIC_*` is inlined at build time and this is a static export, so a build flag alone changes only by redeploy — against a service worker with `aggressiveFrontEndNavCaching` that may serve the old bundle. A per-user runtime mode (`off` / `dry-run` / `live`) is the kill switch that actually works.

> ⚠️ **Deploy note:** `npm run deploy` publishes **hosting only**. This rules change needs `firebase deploy --only firestore:rules`, or the sync fails in production with `permission-denied` while working fine against the emulator.

## Verification

- `tsc --noEmit` clean
- **291 Playwright tests pass** — 247 pre-existing (so the `App.tsx` refactor broke nothing) + 44 new
- `npm run build` succeeds
- `firestore.rules` loads in the Firestore emulator

The 44 new tests are pure logic — no browser, no Firestore, no network — and were written before the implementation.

## Still to come

- **Phase 2 implementation:** `auth.ts`, `client.ts`, `links.ts`, `plan.ts`, `execute.ts`, `sync.ts` per the specced design; E2E against an intercepted `tasks.googleapis.com`
- **Phase 3:** explicit one-time backfill of existing task notes, after dry-run counts are reviewed
- Setup prerequisite: a Web OAuth client in the `notedude2` project and the Tasks API enabled

Non-task notes are out of scope here — they sync with Google Keep, specified separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)