### PR TITLE
Two-way Google Keep sync for non-#tasks-* notes

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -18,6 +18,10 @@ jobs:
           node-version: 24
           cache: npm
 
+      # Keep-sync unit tests. They import only node builtins and their own sources, so
+      # they need no install and run before the slow browser suite for fast feedback.
+      - run: npm run test:unit
+
       - run: npm ci
 
       # Chromium only: playwright.config.ts declares a single chromium project, and the

--- a/e2e/firebase-roundtrip.spec.ts
+++ b/e2e/firebase-roundtrip.spec.ts
@@ -194,6 +194,58 @@ test("security rules: a wrong-typed field is rejected", async ({ page, baseURL }
   expect(res.code).toContain("permission-denied");
 });
 
+async function rawUserPath(
+  page: Page,
+  segments: string[],
+  data?: Record<string, unknown>
+): Promise<WriteResult> {
+  return page.evaluate(
+    ([segs, payload]) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__testUserPath(segs, payload) as Promise<WriteResult>,
+    [segments, data] as [string[], Record<string, unknown> | undefined]
+  );
+}
+
+test.describe("security rules: keepSync mappings are server-only (#142)", () => {
+  // Keep-sync state at users/{uid}/keepSync/{noteId} is written solely by the Admin
+  // SDK in mcp/, which bypasses rules. No rule grants the browser access, so
+  // Firestore's default deny applies. These tests pin that down: forged mapping
+  // state would let a client point a mapping at someone else's Keep note, and the
+  // sync's replace path deletes whatever the mapping names — permanently.
+
+  test("a client cannot write its own keepSync mapping", async ({ page, baseURL }) => {
+    await loadAndSignIn(page, baseURL!);
+    const res = await rawUserPath(page, ["keepSync", "n1"], {
+      keepName: "notes/forged",
+      baseHash: "deadbeef",
+      lastSyncedAt: 1700000000000,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.code).toContain("permission-denied");
+  });
+
+  test("a client cannot read its own keepSync mapping", async ({ page, baseURL }) => {
+    await loadAndSignIn(page, baseURL!);
+    const res = await rawUserPath(page, ["keepSync", "n1"]);
+    expect(res.ok).toBe(false);
+    expect(res.code).toContain("permission-denied");
+  });
+
+  test("the notes collection still works, so the denials above mean something", async ({ page, baseURL }) => {
+    // Control. Without it a broken rules file would make every assertion above pass.
+    await loadAndSignIn(page, baseURL!);
+    const res = await rawUserPath(page, ["notes", "control-note"], {
+      content: "hello",
+      pinned: false,
+      tagPinned: false,
+      createdAt: 1700000000000,
+      updatedAt: 1700000000000,
+    });
+    expect(res.ok).toBe(true);
+  });
+});
+
 test("note is visible in a new browser session (cross-session sync)", async ({ page, browser, baseURL }) => {
   // Session 1: create a note
   await loadAndSignIn(page, baseURL!);

--- a/mcp/.env.example
+++ b/mcp/.env.example
@@ -4,3 +4,22 @@ GOOGLE_APPLICATION_CREDENTIALS=/path/to/notedude2-service-account.json
 
 # Your Firebase Auth UID — find it in Firebase Console → Authentication → Users
 NOTEDUDE_USER_UID=your-uid-here
+
+# ── Google Keep sync (optional) ────────────────────────────────────────────────
+# Only needed for `sync_keep` / `npm run sync:keep`. See README § Google Keep sync.
+# The Keep API is Google Workspace only — it does not work with personal @gmail.com
+# accounts.
+
+# The Workspace user whose Keep notes are synced. The service account impersonates
+# this address via domain-wide delegation.
+GOOGLE_KEEP_SUBJECT=you@yourdomain.com
+
+# Service account key authorised for domain-wide delegation on the Keep scope.
+# Falls back to GOOGLE_APPLICATION_CREDENTIALS when unset — set it separately if
+# your Firebase key is not the one with delegation enabled.
+# GOOGLE_KEEP_SERVICE_ACCOUNT=/path/to/keep-delegated-service-account.json
+
+# What happens to the Keep note when a note leaves sync scope (gains a #tasks-*
+# tag, is archived, or is deleted). "unlink" (default) leaves the Keep note alone;
+# "delete" removes it permanently — the Keep API has no trash, deletes are final.
+# KEEP_ON_LEAVE_SCOPE=unlink

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -41,9 +41,102 @@ The MCP server is already registered in `.claude/settings.json`. Restart Claude 
 | `create_note` | Create a new note |
 | `update_note` | Edit content or pin status |
 | `delete_note` | Permanently delete a note |
+| `sync_keep` | Two-way sync with Google Keep — see below |
 
 ## Example prompts
 
 - *"Show me all my #tasks-today notes"*
 - *"Create a note: Meeting with Alex\nDiscuss Q3 roadmap #work"*
 - *"Find my note about the Firebase setup and summarise it"*
+- *"Do a dry-run Keep sync and show me what would change"*
+
+## Google Keep sync
+
+Two-way sync of every note **not** tagged `#tasks-*`. See spec.md § Google Keep Sync and #142.
+
+### Requirements — read this first
+
+The Keep API is **Google Workspace only**. It does **not** work with personal `@gmail.com` accounts, and there is no way for an individual to self-enable it. You need a Workspace domain and admin console access.
+
+Two API limits shape how sync behaves, and neither is something this implementation can work around:
+
+- **There is no update method.** Keep exposes only `create`, `get`, `list` and `delete`. Pushing a notedude edit to Keep therefore means *delete + recreate*, which mints a new Keep note id and **loses Keep-side labels, reminders, collaborators, colour and pin state**.
+- **`notes.delete` is permanent.** There is no trash, and collaborators lose access immediately.
+
+Because of that, sync is deliberately conservative:
+
+| Situation | What happens |
+|-----------|--------------|
+| Note edited in notedude | Replacement created **first**, then the old Keep note deleted — an interrupted run leaves a duplicate, never a hole |
+| Note edited in Keep | Updated in notedude (no destructive step; Firestore supports real updates) |
+| Both edited | notedude wins; Keep's version is saved as a new `#sync-conflict` note **before** the old one is deleted |
+| Note deleted in Keep | notedude note is **archived** (`#archived`), never hard-deleted |
+| Note gains `#tasks-*`, or is archived | Mapping is tombstoned; the Keep note is **left in place** unless you opt into `--on-leave-scope=delete` |
+| Keep note has attachments | Never replaced or deleted — the API cannot re-upload media, so the attachment would be unrecoverable |
+| Note over 20,000 chars | Skipped and reported, never truncated (notedude allows 100,000, Keep 20,000) |
+
+### 1. Enable the API and create a delegated service account
+
+1. In the [Google Cloud console](https://console.cloud.google.com/apis/library/keep.googleapis.com), enable the **Google Keep API** for your project.
+2. Create a service account and generate a JSON key.
+3. On the service account, enable **domain-wide delegation** and note its **client ID**.
+4. In the [Workspace admin console](https://admin.google.com) → *Security* → *Access and data control* → *API controls* → *Domain-wide delegation*, add the client ID with this scope:
+
+   ```
+   https://www.googleapis.com/auth/keep
+   ```
+
+### 2. Configure
+
+Add to `.env`:
+
+```
+GOOGLE_KEEP_SUBJECT=you@yourdomain.com
+# Only if the delegated key differs from your Firebase one:
+# GOOGLE_KEEP_SERVICE_ACCOUNT=/path/to/keep-delegated-service-account.json
+```
+
+### 3. Run it
+
+Always dry-run first — it prints the plan and touches nothing:
+
+```bash
+npm run sync:keep -- --dry-run
+```
+
+Then for real:
+
+```bash
+npm run sync:keep
+```
+
+Or ask Claude to run the `sync_keep` tool.
+
+Flags: `--dry-run`, and `--on-leave-scope=unlink|delete` (default `unlink`).
+
+### 4. Sync on a schedule
+
+A sample launchd agent is in [`keep/com.notedude.keepsync.plist.sample`](keep/com.notedude.keepsync.plist.sample) — it runs a sync every 30 minutes:
+
+```bash
+sed "s|__REPO__|$PWD|g" keep/com.notedude.keepsync.plist.sample \
+  > ~/Library/LaunchAgents/com.notedude.keepsync.plist
+launchctl load ~/Library/LaunchAgents/com.notedude.keepsync.plist
+```
+
+The equivalent crontab line:
+
+```
+*/30 * * * * cd /path/to/notedude2/mcp && /usr/bin/env node keep/cli.ts >> /tmp/notedude-keepsync.log 2>&1
+```
+
+A run exits non-zero if any operation failed, so cron mail surfaces problems.
+
+### Tests
+
+The sync planner is a pure function, so the whole diff — conflicts, scope changes, the duplication loops — is tested without touching a network:
+
+```bash
+npm test          # in mcp/
+npm run typecheck
+```

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -3,6 +3,10 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import admin from "firebase-admin";
+import { GoogleKeepClient } from "./keep/client.ts";
+import { ConfigError, loadKeepConfig } from "./keep/config.ts";
+import { NotedudeStore } from "./keep/store.ts";
+import { formatReport, runSync } from "./keep/sync.ts";
 
 // ── Firebase init ──────────────────────────────────────────────────────────────
 
@@ -198,6 +202,37 @@ server.tool(
     const content = current + sep + "#archived";
     await ref.update({ content, updatedAt: admin.firestore.FieldValue.serverTimestamp() });
     return { content: [{ type: "text", text: `Archived note ${id}: "${title}"` }] };
+  }
+);
+
+server.tool(
+  "sync_keep",
+  "Sync notes with Google Keep. Every note not tagged #tasks-* is synced two-way. " +
+    "Use dryRun to preview the plan without changing anything.",
+  {
+    dryRun: z.boolean().optional().describe("Preview the plan without executing it (default false)"),
+    onLeaveScope: z
+      .enum(["unlink", "delete"])
+      .optional()
+      .describe(
+        "What to do with the Keep note when a note leaves scope. 'unlink' (default) leaves it in " +
+          "place; 'delete' removes it permanently — Keep has no trash via the API."
+      ),
+  },
+  async ({ dryRun = false, onLeaveScope }) => {
+    let config;
+    try {
+      config = loadKeepConfig();
+    } catch (err) {
+      if (err instanceof ConfigError) return { content: [{ type: "text", text: err.message }] };
+      throw err;
+    }
+    const report = await runSync(
+      new GoogleKeepClient({ keyFile: config.keyFile, subject: config.subject }),
+      new NotedudeStore(db, uid!),
+      { onLeaveScope: onLeaveScope ?? config.onLeaveScope, dryRun }
+    );
+    return { content: [{ type: "text", text: formatReport(report) }] };
   }
 );
 

--- a/mcp/keep/apply.test.ts
+++ b/mcp/keep/apply.test.ts
@@ -1,0 +1,246 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { applyOps } from "./apply.ts";
+import { contentHash } from "./convert.ts";
+import type { KeepClient, KeepNote, NoteStore, SyncMapping } from "./types.ts";
+
+/**
+ * These tests exist for one reason: `notes.delete` is irreversible and there is
+ * no update method, so the *order* of calls is the only thing standing between
+ * a sync and permanent data loss. They assert on a single call log.
+ */
+
+interface Harness {
+  keep: KeepClient;
+  store: NoteStore;
+  log: string[];
+  mappings: SyncMapping[];
+  notes: Map<string, string>;
+}
+
+function harness(opts: { failCreate?: boolean; failDelete?: boolean } = {}): Harness {
+  const log: string[] = [];
+  const mappings: SyncMapping[] = [];
+  const notes = new Map<string, string>();
+  let seq = 0;
+
+  const keep: KeepClient = {
+    async listNotes(): Promise<KeepNote[]> {
+      return [];
+    },
+    async createNote(title, body) {
+      if (opts.failCreate) {
+        log.push("keep.create:FAIL");
+        throw new Error("keep create failed");
+      }
+      const name = `notes/new${++seq}`;
+      log.push(`keep.create:${name}:${title}`);
+      return { name, title, body, updateTime: 1, trashed: false };
+    },
+    async deleteNote(name) {
+      if (opts.failDelete) {
+        log.push(`keep.delete:${name}:FAIL`);
+        throw new Error("keep delete failed");
+      }
+      log.push(`keep.delete:${name}`);
+    },
+  };
+
+  const store: NoteStore = {
+    async listNotes() {
+      return [];
+    },
+    async listMappings() {
+      return mappings;
+    },
+    async createNote(content) {
+      const id = `nd${++seq}`;
+      notes.set(id, content);
+      log.push(`store.create:${id}:${content.split("\n")[0]}`);
+      return id;
+    },
+    async updateNote(noteId, content) {
+      notes.set(noteId, content);
+      log.push(`store.update:${noteId}`);
+    },
+    async archiveNote(noteId) {
+      log.push(`store.archive:${noteId}`);
+    },
+    async saveMapping(m) {
+      const i = mappings.findIndex((x) => x.noteId === m.noteId);
+      if (i === -1) mappings.push(m);
+      else mappings[i] = m;
+      log.push(`store.map:${m.noteId}->${m.keepName}`);
+    },
+    async markUnlinked(noteId, keepDeleted) {
+      log.push(`store.unlink:${noteId}:${keepDeleted}`);
+    },
+  };
+
+  return { keep, store, log, mappings, notes };
+}
+
+// ── the create-before-delete guarantee ─────────────────────────────────────────
+
+test("replace creates the new Keep note before deleting the old one", () => {
+  return (async () => {
+    const h = harness();
+    await applyOps(
+      [{ kind: "replace-keep", noteId: "n1", keepName: "notes/old", content: "Updated" }],
+      h.keep,
+      h.store
+    );
+    assert.deepEqual(h.log, [
+      "keep.create:notes/new1:Updated",
+      "store.map:n1->notes/new1",
+      "keep.delete:notes/old",
+    ]);
+  })();
+});
+
+test("the mapping is repointed before the delete, so a crash never orphans it", async () => {
+  const h = harness();
+  await applyOps(
+    [{ kind: "replace-keep", noteId: "n1", keepName: "notes/old", content: "Updated" }],
+    h.keep,
+    h.store
+  );
+  const mapIdx = h.log.indexOf("store.map:n1->notes/new1");
+  const delIdx = h.log.indexOf("keep.delete:notes/old");
+  assert.ok(mapIdx !== -1 && delIdx !== -1);
+  assert.ok(mapIdx < delIdx, "mapping must be saved before the old note is deleted");
+});
+
+test("a failed create never reaches the delete — the original survives", async () => {
+  const h = harness({ failCreate: true });
+  const res = await applyOps(
+    [{ kind: "replace-keep", noteId: "n1", keepName: "notes/old", content: "Updated" }],
+    h.keep,
+    h.store
+  );
+  assert.equal(res.failed.length, 1);
+  assert.ok(!h.log.some((l) => l.startsWith("keep.delete")), "must not delete after a failed create");
+});
+
+test("a failed delete leaves a duplicate, not a hole, and the mapping points at the live note", async () => {
+  const h = harness({ failDelete: true });
+  const res = await applyOps(
+    [{ kind: "replace-keep", noteId: "n1", keepName: "notes/old", content: "Updated" }],
+    h.keep,
+    h.store
+  );
+  assert.equal(res.failed.length, 1);
+  assert.equal(h.mappings[0].keepName, "notes/new1");
+  assert.equal(h.mappings[0].baseHash, contentHash("Updated"));
+});
+
+// ── conflict ordering ──────────────────────────────────────────────────────────
+
+test("a conflict preserves Keep's version before destroying the note holding it", async () => {
+  const h = harness();
+  await applyOps(
+    [
+      {
+        kind: "conflict",
+        noteId: "n1",
+        keepName: "notes/old",
+        content: "notedude wins",
+        conflictContent: "keep version",
+      },
+    ],
+    h.keep,
+    h.store
+  );
+  const savedIdx = h.log.findIndex((l) => l.startsWith("store.create:"));
+  const delIdx = h.log.indexOf("keep.delete:notes/old");
+  assert.ok(savedIdx !== -1, "the losing version must be written to notedude");
+  assert.ok(savedIdx < delIdx, "it must be written before the Keep note is deleted");
+});
+
+test("the conflict copy is tagged #sync-conflict so it never syncs back", async () => {
+  const h = harness();
+  await applyOps(
+    [
+      {
+        kind: "conflict",
+        noteId: "n1",
+        keepName: "notes/old",
+        content: "notedude wins",
+        conflictContent: "keep version",
+      },
+    ],
+    h.keep,
+    h.store
+  );
+  const copy = [...h.notes.values()].find((c) => c.includes("keep version"));
+  assert.equal(copy, "keep version #sync-conflict");
+});
+
+// ── remaining operations ───────────────────────────────────────────────────────
+
+test("create-keep records a mapping with the content hash as merge base", async () => {
+  const h = harness();
+  await applyOps([{ kind: "create-keep", noteId: "n1", content: "Buy milk" }], h.keep, h.store);
+  assert.deepEqual(h.mappings[0], {
+    noteId: "n1",
+    keepName: "notes/new1",
+    baseHash: contentHash("Buy milk"),
+    lastSyncedAt: h.mappings[0].lastSyncedAt,
+  });
+});
+
+test("create-notedude maps the new local note to the Keep note", async () => {
+  const h = harness();
+  await applyOps([{ kind: "create-notedude", keepName: "notes/k1", content: "From Keep" }], h.keep, h.store);
+  assert.equal(h.mappings[0].keepName, "notes/k1");
+  assert.equal(h.mappings[0].baseHash, contentHash("From Keep"));
+});
+
+test("archive-notedude soft-archives and tombstones, never deleting from Keep", async () => {
+  const h = harness();
+  await applyOps([{ kind: "archive-notedude", noteId: "n1", keepName: "notes/k1" }], h.keep, h.store);
+  assert.deepEqual(h.log, ["store.archive:n1", "store.unlink:n1:true"]);
+});
+
+test("unlink without deleteKeep leaves the Keep note untouched", async () => {
+  const h = harness();
+  await applyOps([{ kind: "unlink", noteId: "n1", keepName: "notes/k1", deleteKeep: false }], h.keep, h.store);
+  assert.deepEqual(h.log, ["store.unlink:n1:false"]);
+});
+
+test("unlink with deleteKeep removes the Keep note", async () => {
+  const h = harness();
+  await applyOps([{ kind: "unlink", noteId: "n1", keepName: "notes/k1", deleteKeep: true }], h.keep, h.store);
+  assert.deepEqual(h.log, ["keep.delete:notes/k1", "store.unlink:n1:true"]);
+});
+
+test("rebase writes only the mapping — no note is touched on either side", async () => {
+  const h = harness();
+  await applyOps([{ kind: "rebase", noteId: "n1", keepName: "notes/k1", content: "same" }], h.keep, h.store);
+  assert.deepEqual(h.log, ["store.map:n1->notes/k1"]);
+});
+
+test("skip performs no writes and is reported back", async () => {
+  const h = harness();
+  const res = await applyOps([{ kind: "skip", noteId: "n1", reason: "too-large" }], h.keep, h.store);
+  assert.deepEqual(h.log, []);
+  assert.equal(res.skipped.length, 1);
+  assert.equal(res.applied.length, 0);
+});
+
+// ── resilience ─────────────────────────────────────────────────────────────────
+
+test("one failing operation does not abandon the rest of the run", async () => {
+  const h = harness({ failCreate: true });
+  const res = await applyOps(
+    [
+      { kind: "create-keep", noteId: "n1", content: "will fail" },
+      { kind: "unlink", noteId: "n2", keepName: "notes/k2", deleteKeep: false },
+    ],
+    h.keep,
+    h.store
+  );
+  assert.equal(res.failed.length, 1);
+  assert.equal(res.applied.length, 1);
+  assert.equal(res.applied[0].kind, "unlink");
+});

--- a/mcp/keep/apply.ts
+++ b/mcp/keep/apply.ts
@@ -1,0 +1,132 @@
+import { contentHash, toKeep } from "./convert.ts";
+import type { KeepClient, NoteStore, SyncOp } from "./types.ts";
+
+/**
+ * Executes a plan. See spec.md § Constraints imposed by the Keep API.
+ *
+ * The ordering rules here are the whole safety story, because `notes.delete` is
+ * irreversible and there is no update method:
+ *
+ *  1. The replacement Keep note is created **before** the old one is deleted, so
+ *     an interrupted run leaves a duplicate rather than a hole.
+ *  2. The mapping is repointed at the new note **before** the delete, so a crash
+ *     between the two never leaves the mapping aimed at a deleted note.
+ *  3. A conflict's losing content is written to notedude **before** the Keep note
+ *     holding it is destroyed.
+ */
+
+export interface ApplyResult {
+  applied: SyncOp[];
+  /** Operations that threw, with the failure. The run continues past them. */
+  failed: { op: SyncOp; error: string }[];
+  skipped: SyncOp[];
+}
+
+/** Append a tag the way the app does, so the result is a well-formed note. */
+function appendTag(content: string, tag: string): string {
+  const sep = content.endsWith("\n") || content === "" ? "" : " ";
+  return content + sep + tag;
+}
+
+export async function applyOps(
+  ops: SyncOp[],
+  keep: KeepClient,
+  store: NoteStore
+): Promise<ApplyResult> {
+  const applied: SyncOp[] = [];
+  const failed: { op: SyncOp; error: string }[] = [];
+  const skipped: SyncOp[] = [];
+
+  /** Create in Keep, point the mapping at it, then remove the superseded note. */
+  const replace = async (noteId: string, oldKeepName: string, content: string) => {
+    const { title, body } = toKeep(content);
+    const created = await keep.createNote(title, body);
+    await store.saveMapping({
+      noteId,
+      keepName: created.name,
+      baseHash: contentHash(content),
+      lastSyncedAt: Date.now(),
+    });
+    await keep.deleteNote(oldKeepName);
+  };
+
+  for (const op of ops) {
+    try {
+      switch (op.kind) {
+        case "skip":
+          skipped.push(op);
+          continue;
+
+        case "create-keep": {
+          const { title, body } = toKeep(op.content);
+          const created = await keep.createNote(title, body);
+          await store.saveMapping({
+            noteId: op.noteId,
+            keepName: created.name,
+            baseHash: contentHash(op.content),
+            lastSyncedAt: Date.now(),
+          });
+          break;
+        }
+
+        case "replace-keep":
+          await replace(op.noteId, op.keepName, op.content);
+          break;
+
+        case "create-notedude": {
+          const noteId = await store.createNote(op.content);
+          await store.saveMapping({
+            noteId,
+            keepName: op.keepName,
+            baseHash: contentHash(op.content),
+            lastSyncedAt: Date.now(),
+          });
+          break;
+        }
+
+        case "update-notedude":
+          await store.updateNote(op.noteId, op.content);
+          await store.saveMapping({
+            noteId: op.noteId,
+            keepName: op.keepName,
+            baseHash: contentHash(op.content),
+            lastSyncedAt: Date.now(),
+          });
+          break;
+
+        case "conflict":
+          // Preserve the losing version first — after the replace below, the Keep
+          // note holding it is permanently gone.
+          await store.createNote(appendTag(op.conflictContent, "#sync-conflict"));
+          await replace(op.noteId, op.keepName, op.content);
+          break;
+
+        case "rebase":
+          // Both sides already agree; only the stale merge base needs moving.
+          await store.saveMapping({
+            noteId: op.noteId,
+            keepName: op.keepName,
+            baseHash: contentHash(op.content),
+            lastSyncedAt: Date.now(),
+          });
+          break;
+
+        case "archive-notedude":
+          await store.archiveNote(op.noteId);
+          await store.markUnlinked(op.noteId, true);
+          break;
+
+        case "unlink":
+          if (op.deleteKeep) await keep.deleteNote(op.keepName);
+          await store.markUnlinked(op.noteId, op.deleteKeep);
+          break;
+      }
+      applied.push(op);
+    } catch (err) {
+      // One bad note must not abandon the rest of the run.
+      failed.push({ op, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  return { applied, failed, skipped };
+}

--- a/mcp/keep/cli.ts
+++ b/mcp/keep/cli.ts
@@ -1,0 +1,54 @@
+import "dotenv/config";
+import admin from "firebase-admin";
+import { GoogleKeepClient } from "./client.ts";
+import { ConfigError, loadKeepConfig } from "./config.ts";
+import { NotedudeStore } from "./store.ts";
+import { formatReport, runSync } from "./sync.ts";
+import type { LeaveScopePolicy } from "./types.ts";
+
+/**
+ * CLI entry point for Keep sync — `npm run sync:keep`, suitable for cron/launchd.
+ *
+ *   --dry-run                 print the plan without executing it
+ *   --on-leave-scope=delete   delete the Keep note when a note leaves scope
+ *                             (default: unlink, which leaves it in place)
+ */
+
+const argv = process.argv.slice(2);
+const dryRun = argv.includes("--dry-run");
+const policyArg = argv.find((a) => a.startsWith("--on-leave-scope="))?.split("=")[1];
+
+if (policyArg && policyArg !== "unlink" && policyArg !== "delete") {
+  console.error(`--on-leave-scope must be "unlink" or "delete", got "${policyArg}".`);
+  process.exit(2);
+}
+
+let config;
+try {
+  config = loadKeepConfig();
+} catch (err) {
+  if (err instanceof ConfigError) {
+    console.error(err.message);
+    process.exit(2);
+  }
+  throw err;
+}
+
+const uid = process.env.NOTEDUDE_USER_UID;
+if (!uid) {
+  console.error("Missing NOTEDUDE_USER_UID in .env");
+  process.exit(2);
+}
+
+admin.initializeApp({ credential: admin.credential.applicationDefault(), projectId: "notedude2" });
+
+const report = await runSync(
+  new GoogleKeepClient({ keyFile: config.keyFile, subject: config.subject }),
+  new NotedudeStore(admin.firestore(), uid),
+  { onLeaveScope: (policyArg as LeaveScopePolicy) ?? config.onLeaveScope, dryRun }
+);
+
+console.log(formatReport(report));
+
+// A failed operation must surface to cron as a non-zero exit.
+process.exit(report.result && report.result.failed.length > 0 ? 1 : 0);

--- a/mcp/keep/client.ts
+++ b/mcp/keep/client.ts
@@ -1,0 +1,100 @@
+import { JWT } from "google-auth-library";
+import { listToText } from "./convert.ts";
+import type { KeepClient, KeepNote } from "./types.ts";
+
+/**
+ * Google Keep REST client.
+ *
+ * The Keep API is Workspace-only and has no update method — see spec.md
+ * § Constraints imposed by the Keep API. This client therefore exposes exactly
+ * list / create / delete, which is the whole write surface available to us.
+ */
+
+const KEEP_API = "https://keep.googleapis.com/v1";
+export const KEEP_SCOPE = "https://www.googleapis.com/auth/keep";
+
+interface RawListItem {
+  text?: { text?: string };
+  checked?: boolean;
+}
+
+interface RawNote {
+  name?: string;
+  title?: string;
+  body?: { text?: { text?: string }; list?: { listItems?: RawListItem[] } };
+  updateTime?: string;
+  trashed?: boolean;
+  trashTime?: string;
+  attachments?: unknown[];
+}
+
+/** Normalise the API's note shape, flattening checklists to markdown checkboxes. */
+export function normaliseNote(raw: RawNote): KeepNote {
+  const list = raw.body?.list?.listItems;
+  const isList = Array.isArray(list);
+  return {
+    name: raw.name ?? "",
+    title: raw.title ?? "",
+    body: isList ? listToText(list) : raw.body?.text?.text ?? "",
+    updateTime: raw.updateTime ? Date.parse(raw.updateTime) : 0,
+    // trashTime is set even when `trashed` is absent from the payload.
+    trashed: raw.trashed === true || Boolean(raw.trashTime),
+    isList,
+    hasAttachments: Array.isArray(raw.attachments) && raw.attachments.length > 0,
+  };
+}
+
+export interface GoogleKeepClientOptions {
+  /** Service account JSON key path. Needs domain-wide delegation for KEEP_SCOPE. */
+  keyFile: string;
+  /** Workspace user to impersonate — the owner of the notes. */
+  subject: string;
+}
+
+export class GoogleKeepClient implements KeepClient {
+  private readonly auth: JWT;
+
+  constructor({ keyFile, subject }: GoogleKeepClientOptions) {
+    // Domain-wide delegation: the service account acts *as* the user, which is
+    // the only way to reach a Workspace user's own Keep notes.
+    this.auth = new JWT({ keyFile, scopes: [KEEP_SCOPE], subject });
+  }
+
+  async listNotes(): Promise<KeepNote[]> {
+    const notes: KeepNote[] = [];
+    let pageToken: string | undefined;
+
+    do {
+      const url = new URL(`${KEEP_API}/notes`);
+      url.searchParams.set("pageSize", "100");
+      if (pageToken) url.searchParams.set("pageToken", pageToken);
+
+      const res = await this.auth.request<{ notes?: RawNote[]; nextPageToken?: string }>({
+        url: url.toString(),
+        method: "GET",
+      });
+      for (const raw of res.data.notes ?? []) notes.push(normaliseNote(raw));
+      pageToken = res.data.nextPageToken;
+    } while (pageToken);
+
+    return notes;
+  }
+
+  async createNote(title: string, body: string): Promise<KeepNote> {
+    const res = await this.auth.request<RawNote>({
+      url: `${KEEP_API}/notes`,
+      method: "POST",
+      data: { title, body: { text: { text: body } } },
+    });
+    return normaliseNote(res.data);
+  }
+
+  /**
+   * Permanent. The API offers no trash operation — "removes the resource
+   * immediately and cannot be undone". Callers must have created the
+   * replacement first.
+   */
+  async deleteNote(name: string): Promise<void> {
+    await this.auth.request({ url: `${KEEP_API}/${name}`, method: "DELETE" });
+  }
+}

--- a/mcp/keep/com.notedude.keepsync.plist.sample
+++ b/mcp/keep/com.notedude.keepsync.plist.sample
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Sample launchd agent for scheduled Google Keep sync.
+
+  Install:
+    sed "s|__REPO__|$PWD|g" keep/com.notedude.keepsync.plist.sample \
+      > ~/Library/LaunchAgents/com.notedude.keepsync.plist
+    launchctl load ~/Library/LaunchAgents/com.notedude.keepsync.plist
+
+  __REPO__ is substituted with the absolute path to the mcp/ directory.
+  Credentials are read from mcp/.env — none are stored in this file.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.notedude.keepsync</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>node</string>
+        <string>__REPO__/keep/cli.ts</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+
+    <!-- Every 30 minutes. -->
+    <key>StartInterval</key>
+    <integer>1800</integer>
+
+    <!-- Do not fire a missed run on wake; the next interval is soon enough and a
+         burst of syncs after a laptop opens is pure churn. -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/notedude-keepsync.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/notedude-keepsync.err</string>
+</dict>
+</plist>

--- a/mcp/keep/config.test.ts
+++ b/mcp/keep/config.test.ts
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ConfigError, loadKeepConfig } from "./config.ts";
+
+test("reads a complete configuration", () => {
+  const c = loadKeepConfig({
+    GOOGLE_KEEP_SERVICE_ACCOUNT: "/keys/keep.json",
+    GOOGLE_KEEP_SUBJECT: "me@corp.com",
+    KEEP_ON_LEAVE_SCOPE: "delete",
+  } as NodeJS.ProcessEnv);
+  assert.deepEqual(c, { keyFile: "/keys/keep.json", subject: "me@corp.com", onLeaveScope: "delete" });
+});
+
+test("falls back to the Firebase service account key", () => {
+  const c = loadKeepConfig({
+    GOOGLE_APPLICATION_CREDENTIALS: "/keys/firebase.json",
+    GOOGLE_KEEP_SUBJECT: "me@corp.com",
+  } as NodeJS.ProcessEnv);
+  assert.equal(c.keyFile, "/keys/firebase.json");
+});
+
+test("defaults to the non-destructive leave-scope policy", () => {
+  const c = loadKeepConfig({
+    GOOGLE_APPLICATION_CREDENTIALS: "/k.json",
+    GOOGLE_KEEP_SUBJECT: "me@corp.com",
+  } as NodeJS.ProcessEnv);
+  assert.equal(c.onLeaveScope, "unlink");
+});
+
+test("a missing key file is a clear error", () => {
+  assert.throws(
+    () => loadKeepConfig({ GOOGLE_KEEP_SUBJECT: "me@corp.com" } as NodeJS.ProcessEnv),
+    (e: unknown) => e instanceof ConfigError && /GOOGLE_KEEP_SERVICE_ACCOUNT/.test((e as Error).message)
+  );
+});
+
+test("a missing subject explains the Workspace requirement", () => {
+  assert.throws(
+    () => loadKeepConfig({ GOOGLE_APPLICATION_CREDENTIALS: "/k.json" } as NodeJS.ProcessEnv),
+    (e: unknown) => e instanceof ConfigError && /gmail\.com/.test((e as Error).message)
+  );
+});
+
+test("an unrecognised leave-scope policy is rejected rather than assumed", () => {
+  assert.throws(
+    () =>
+      loadKeepConfig({
+        GOOGLE_APPLICATION_CREDENTIALS: "/k.json",
+        GOOGLE_KEEP_SUBJECT: "me@corp.com",
+        KEEP_ON_LEAVE_SCOPE: "purge",
+      } as NodeJS.ProcessEnv),
+    ConfigError
+  );
+});

--- a/mcp/keep/config.ts
+++ b/mcp/keep/config.ts
@@ -1,0 +1,42 @@
+import type { LeaveScopePolicy } from "./types.ts";
+
+/**
+ * Environment configuration for Keep sync.
+ *
+ * The Keep service account is separate from the Firebase one because it needs
+ * domain-wide delegation authorised in the Workspace admin console, which the
+ * Firebase key normally does not have. It falls back to the Firebase key so a
+ * single-key setup still works.
+ */
+export interface KeepSyncConfig {
+  keyFile: string;
+  subject: string;
+  onLeaveScope: LeaveScopePolicy;
+}
+
+export class ConfigError extends Error {}
+
+export function loadKeepConfig(env: NodeJS.ProcessEnv = process.env): KeepSyncConfig {
+  const keyFile = env.GOOGLE_KEEP_SERVICE_ACCOUNT || env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (!keyFile) {
+    throw new ConfigError(
+      "Missing GOOGLE_KEEP_SERVICE_ACCOUNT (or GOOGLE_APPLICATION_CREDENTIALS) — " +
+        "path to a service account key with domain-wide delegation for the Keep scope."
+    );
+  }
+
+  const subject = env.GOOGLE_KEEP_SUBJECT;
+  if (!subject) {
+    throw new ConfigError(
+      "Missing GOOGLE_KEEP_SUBJECT — the Workspace user to impersonate, e.g. you@yourdomain.com. " +
+        "The Keep API is not available for personal @gmail.com accounts."
+    );
+  }
+
+  const raw = env.KEEP_ON_LEAVE_SCOPE ?? "unlink";
+  if (raw !== "unlink" && raw !== "delete") {
+    throw new ConfigError(`KEEP_ON_LEAVE_SCOPE must be "unlink" or "delete", got "${raw}".`);
+  }
+
+  return { keyFile, subject, onLeaveScope: raw };
+}

--- a/mcp/keep/convert.test.ts
+++ b/mcp/keep/convert.test.ts
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { canonical, contentHash, fromKeep, listToText, toKeep } from "./convert.ts";
+
+test("first line becomes the Keep title, the rest the body", () => {
+  assert.deepEqual(toKeep("Shopping\nmilk\neggs"), { title: "Shopping", body: "milk\neggs" });
+});
+
+test("a single-line note has an empty body", () => {
+  assert.deepEqual(toKeep("Buy milk"), { title: "Buy milk", body: "" });
+});
+
+test("fromKeep rejoins title and body", () => {
+  assert.equal(fromKeep({ title: "Shopping", body: "milk\neggs" }), "Shopping\nmilk\neggs");
+});
+
+test("fromKeep omits the separator when the body is empty", () => {
+  assert.equal(fromKeep({ title: "Buy milk", body: "" }), "Buy milk");
+});
+
+test("an empty title round-trips (a note may start with a blank line)", () => {
+  assert.equal(fromKeep(toKeep("\nbody")), "\nbody");
+});
+
+test("canonical form is idempotent — the property the merge base relies on", () => {
+  for (const c of ["Buy milk", "Shopping\nmilk\neggs", "\nbody", "Title\n", "a\n\n\nb", ""]) {
+    assert.equal(canonical(canonical(c)), canonical(c), `not idempotent for ${JSON.stringify(c)}`);
+  }
+});
+
+test("a trailing newline canonicalises away so it is not misread as a change every run", () => {
+  assert.equal(canonical("Buy milk\n"), canonical("Buy milk"));
+  assert.equal(contentHash("Buy milk\n"), contentHash("Buy milk"));
+});
+
+test("interior blank lines are preserved — only the round-trip loss is normalised", () => {
+  assert.equal(canonical("Title\n\nbody"), "Title\n\nbody");
+});
+
+test("different content hashes differently", () => {
+  assert.notEqual(contentHash("Buy milk"), contentHash("Buy eggs"));
+});
+
+test("hashing is stable across calls", () => {
+  assert.equal(contentHash("Shopping\nmilk"), contentHash("Shopping\nmilk"));
+});
+
+test("Keep checklists render as markdown checkboxes", () => {
+  const text = listToText([
+    { text: { text: "milk" }, checked: false },
+    { text: { text: "eggs" }, checked: true },
+  ]);
+  assert.equal(text, "- [ ] milk\n- [x] eggs");
+});
+
+test("checklist rendering survives an empty list", () => {
+  assert.equal(listToText([]), "");
+});
+
+test("checklist rendering tolerates missing text", () => {
+  assert.equal(listToText([{ checked: false }]), "- [ ] ");
+});

--- a/mcp/keep/convert.ts
+++ b/mcp/keep/convert.ts
@@ -1,0 +1,51 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Mapping between notedude's single `content` string and Keep's {title, body}
+ * shape, plus the content hashing that change detection is built on.
+ */
+
+/** A checklist item as returned by the Keep API. */
+export interface KeepListItem {
+  text?: { text?: string };
+  checked?: boolean;
+}
+
+/** Split notedude content into Keep's title/body pair. First line is the title. */
+export function toKeep(content: string): { title: string; body: string } {
+  const nl = content.indexOf("\n");
+  if (nl === -1) return { title: content, body: "" };
+  return { title: content.slice(0, nl), body: content.slice(nl + 1) };
+}
+
+/** Rejoin a Keep title/body pair into notedude content. */
+export function fromKeep(note: { title: string; body: string }): string {
+  return note.body === "" ? note.title : `${note.title}\n${note.body}`;
+}
+
+/**
+ * The form content takes after a round trip through Keep.
+ *
+ * The trip is lossy for trailing whitespace — "Title\n" comes back as "Title" —
+ * so change detection compares canonical forms. Hashing the raw content instead
+ * would flag every synced note as locally modified on every single run.
+ */
+export function canonical(content: string): string {
+  return fromKeep(toKeep(content));
+}
+
+/** Merge-base hash. Taken over the canonical form, for the reason above. */
+export function contentHash(content: string): string {
+  return createHash("sha256").update(canonical(content), "utf8").digest("hex");
+}
+
+/**
+ * Render a Keep checklist as markdown checkboxes.
+ *
+ * notedude stores plain text, and the Keep API cannot update a note in place, so
+ * a checklist edited in notedude comes back as a text note. Round-tripping a
+ * checklist degrades it — see spec.md § Content mapping.
+ */
+export function listToText(items: KeepListItem[]): string {
+  return items.map((i) => `- [${i.checked ? "x" : " "}] ${i.text?.text ?? ""}`).join("\n");
+}

--- a/mcp/keep/plan.test.ts
+++ b/mcp/keep/plan.test.ts
@@ -1,0 +1,369 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { contentHash, toKeep } from "./convert.ts";
+import { planSync } from "./plan.ts";
+import type { KeepNote, NotedudeNote, SyncMapping, SyncOp } from "./types.ts";
+
+// ── builders ───────────────────────────────────────────────────────────────────
+
+function note(id: string, content: string, updatedAt = 1000): NotedudeNote {
+  return { id, content, updatedAt };
+}
+
+/** A Keep note holding `content`, so tests can talk in notedude terms throughout. */
+function keep(name: string, content: string, extra: Partial<KeepNote> = {}): KeepNote {
+  const { title, body } = toKeep(content);
+  return { name, title, body, updateTime: 1000, trashed: false, ...extra };
+}
+
+/** A mapping whose merge base is `baseContent` — i.e. both sides last agreed on it. */
+function mapping(noteId: string, keepName: string, baseContent: string, extra: Partial<SyncMapping> = {}): SyncMapping {
+  return { noteId, keepName, baseHash: contentHash(baseContent), lastSyncedAt: 1000, ...extra };
+}
+
+function plan(
+  notes: NotedudeNote[],
+  keepNotes: KeepNote[],
+  mappings: SyncMapping[],
+  onLeaveScope: "unlink" | "delete" = "unlink"
+): SyncOp[] {
+  return planSync({ notes, keepNotes, mappings, onLeaveScope });
+}
+
+function kinds(ops: SyncOp[]): string[] {
+  return ops.map((o) => o.kind);
+}
+
+function only<K extends SyncOp["kind"]>(ops: SyncOp[], kind: K): Extract<SyncOp, { kind: K }>[] {
+  return ops.filter((o) => o.kind === kind) as Extract<SyncOp, { kind: K }>[];
+}
+
+// ── first sync ─────────────────────────────────────────────────────────────────
+
+test("a new notedude note is created in Keep", () => {
+  const ops = plan([note("n1", "Buy milk")], [], []);
+  assert.deepEqual(kinds(ops), ["create-keep"]);
+  assert.deepEqual(only(ops, "create-keep")[0], { kind: "create-keep", noteId: "n1", content: "Buy milk" });
+});
+
+test("a new Keep note is created in notedude", () => {
+  const ops = plan([], [keep("notes/k1", "From Keep")], []);
+  assert.deepEqual(only(ops, "create-notedude")[0], {
+    kind: "create-notedude",
+    keepName: "notes/k1",
+    content: "From Keep",
+  });
+});
+
+test("a #tasks-* note is never pushed to Keep and is not reported as a skip", () => {
+  // Out-of-scope-by-design is not news; only genuine failures are reported.
+  assert.deepEqual(plan([note("n1", "Call vet #tasks-today")], [], []), []);
+});
+
+test("an oversized note is reported rather than silently dropped", () => {
+  const ops = plan([note("n1", "x".repeat(30_000))], [], []);
+  assert.deepEqual(kinds(ops), ["skip"]);
+  assert.equal(only(ops, "skip")[0].reason, "too-large");
+  assert.equal(only(ops, "skip")[0].noteId, "n1");
+});
+
+// ── steady state ───────────────────────────────────────────────────────────────
+
+test("an unchanged pair produces no operations", () => {
+  const ops = plan([note("n1", "Buy milk")], [keep("notes/k1", "Buy milk")], [mapping("n1", "notes/k1", "Buy milk")]);
+  assert.deepEqual(ops, []);
+});
+
+test("a trailing-newline-only difference is not a change", () => {
+  const ops = plan(
+    [note("n1", "Buy milk\n")],
+    [keep("notes/k1", "Buy milk")],
+    [mapping("n1", "notes/k1", "Buy milk")]
+  );
+  assert.deepEqual(ops, []);
+});
+
+// ── one-sided changes ──────────────────────────────────────────────────────────
+
+test("a notedude edit replaces the Keep note", () => {
+  const ops = plan(
+    [note("n1", "Buy oat milk")],
+    [keep("notes/k1", "Buy milk")],
+    [mapping("n1", "notes/k1", "Buy milk")]
+  );
+  assert.deepEqual(only(ops, "replace-keep")[0], {
+    kind: "replace-keep",
+    noteId: "n1",
+    keepName: "notes/k1",
+    content: "Buy oat milk",
+  });
+});
+
+test("a notedude edit that outgrows Keep's cap is reported, and the Keep note is left alone", () => {
+  const ops = plan(
+    [note("n1", "x".repeat(30_000))],
+    [keep("notes/k1", "Buy milk")],
+    [mapping("n1", "notes/k1", "Buy milk")]
+  );
+  assert.deepEqual(kinds(ops), ["skip"]);
+  assert.equal(only(ops, "skip")[0].reason, "too-large");
+});
+
+test("a Keep edit updates the notedude note", () => {
+  const ops = plan(
+    [note("n1", "Buy milk")],
+    [keep("notes/k1", "Buy oat milk")],
+    [mapping("n1", "notes/k1", "Buy milk")]
+  );
+  assert.deepEqual(only(ops, "update-notedude")[0], {
+    kind: "update-notedude",
+    noteId: "n1",
+    keepName: "notes/k1",
+    content: "Buy oat milk",
+  });
+});
+
+// ── conflicts ──────────────────────────────────────────────────────────────────
+
+test("both sides changed: notedude wins and Keep's version is preserved", () => {
+  const ops = plan(
+    [note("n1", "notedude version")],
+    [keep("notes/k1", "keep version")],
+    [mapping("n1", "notes/k1", "base")]
+  );
+  assert.deepEqual(only(ops, "conflict")[0], {
+    kind: "conflict",
+    noteId: "n1",
+    keepName: "notes/k1",
+    content: "notedude version",
+    conflictContent: "keep version",
+  });
+});
+
+test("both sides changed to the same content is a rebase, not a conflict", () => {
+  const ops = plan(
+    [note("n1", "same new text")],
+    [keep("notes/k1", "same new text")],
+    [mapping("n1", "notes/k1", "base")]
+  );
+  assert.deepEqual(kinds(ops), ["rebase"]);
+});
+
+// ── deletion ───────────────────────────────────────────────────────────────────
+
+test("a note deleted in Keep is archived in notedude, never hard-deleted", () => {
+  const ops = plan([note("n1", "Buy milk")], [], [mapping("n1", "notes/k1", "Buy milk")]);
+  assert.deepEqual(only(ops, "archive-notedude")[0], {
+    kind: "archive-notedude",
+    noteId: "n1",
+    keepName: "notes/k1",
+  });
+});
+
+test("a note trashed in Keep is treated as deleted", () => {
+  const ops = plan(
+    [note("n1", "Buy milk")],
+    [keep("notes/k1", "Buy milk", { trashed: true })],
+    [mapping("n1", "notes/k1", "Buy milk")]
+  );
+  assert.deepEqual(kinds(ops), ["archive-notedude"]);
+});
+
+// ── leaving scope ──────────────────────────────────────────────────────────────
+
+test("gaining a #tasks-* tag unlinks the pair without deleting the Keep note by default", () => {
+  const ops = plan(
+    [note("n1", "Buy milk #tasks-today")],
+    [keep("notes/k1", "Buy milk")],
+    [mapping("n1", "notes/k1", "Buy milk")]
+  );
+  assert.deepEqual(only(ops, "unlink")[0], {
+    kind: "unlink",
+    noteId: "n1",
+    keepName: "notes/k1",
+    deleteKeep: false,
+  });
+});
+
+test("--on-leave-scope=delete opts in to removing the Keep note", () => {
+  const ops = plan(
+    [note("n1", "Buy milk #tasks-today")],
+    [keep("notes/k1", "Buy milk")],
+    [mapping("n1", "notes/k1", "Buy milk")],
+    "delete"
+  );
+  assert.equal(only(ops, "unlink")[0].deleteKeep, true);
+});
+
+test("archiving in notedude unlinks rather than deleting from Keep", () => {
+  const ops = plan(
+    [note("n1", "Buy milk #archived")],
+    [keep("notes/k1", "Buy milk")],
+    [mapping("n1", "notes/k1", "Buy milk")]
+  );
+  assert.deepEqual(kinds(ops), ["unlink"]);
+});
+
+test("a notedude note deleted outright unlinks its Keep counterpart", () => {
+  const ops = plan([], [keep("notes/k1", "Buy milk")], [mapping("n1", "notes/k1", "Buy milk")]);
+  assert.deepEqual(kinds(ops), ["unlink"]);
+});
+
+// ── the duplication loop these tombstones exist to prevent ─────────────────────
+
+test("an unlinked Keep note is not re-imported, which would duplicate it forever", () => {
+  // Without the tombstone: unlink leaves the Keep note orphaned, the next run sees a
+  // Keep note with no mapping, imports it as new, and the pair multiplies each run.
+  const ops = plan([], [keep("notes/k1", "Buy milk")], [mapping("n1", "notes/k1", "Buy milk", { unlinked: true })]);
+  assert.deepEqual(ops, []);
+});
+
+test("a Keep note whose content would be out of scope is not imported", () => {
+  // Importing it would create an out-of-scope notedude note, which unlinks on the
+  // next run, orphaning the Keep note — the same loop from the other direction.
+  const ops = plan([], [keep("notes/k1", "Call vet #tasks-today")], []);
+  assert.deepEqual(ops, []);
+});
+
+test("an oversized Keep note is reported rather than imported silently", () => {
+  const ops = plan([], [keep("notes/k1", "x".repeat(30_000))], []);
+  assert.deepEqual(kinds(ops), ["skip"]);
+  assert.equal(only(ops, "skip")[0].keepName, "notes/k1");
+});
+
+test("a blank Keep note is ignored", () => {
+  assert.deepEqual(plan([], [keep("notes/k1", "")], []), []);
+});
+
+// ── re-entering scope ──────────────────────────────────────────────────────────
+
+test("dropping the #tasks-* tag relinks to the existing Keep note", () => {
+  const ops = plan(
+    [note("n1", "Buy milk again")],
+    [keep("notes/k1", "Buy milk")],
+    [mapping("n1", "notes/k1", "Buy milk", { unlinked: true })]
+  );
+  assert.deepEqual(only(ops, "replace-keep")[0], {
+    kind: "replace-keep",
+    noteId: "n1",
+    keepName: "notes/k1",
+    content: "Buy milk again",
+  });
+});
+
+test("re-entering scope after the Keep note was deleted creates a fresh one", () => {
+  const ops = plan(
+    [note("n1", "Buy milk")],
+    [],
+    [mapping("n1", "notes/k1", "Buy milk", { unlinked: true, keepDeleted: true })]
+  );
+  assert.deepEqual(kinds(ops), ["create-keep"]);
+});
+
+test("an unlinked pair that stays out of scope produces nothing", () => {
+  const ops = plan(
+    [note("n1", "Buy milk #tasks-today")],
+    [keep("notes/k1", "Buy milk")],
+    [mapping("n1", "notes/k1", "Buy milk", { unlinked: true })]
+  );
+  assert.deepEqual(ops, []);
+});
+
+// ── attachments are unrecoverable ──────────────────────────────────────────────
+
+test("a local edit is never pushed over a Keep note with attachments", () => {
+  // Replacing means delete + recreate, and the API has no media upload — the
+  // attachment would be destroyed with no way to restore it.
+  const ops = plan(
+    [note("n1", "Edited locally")],
+    [keep("notes/k1", "base", { hasAttachments: true })],
+    [mapping("n1", "notes/k1", "base")]
+  );
+  assert.deepEqual(kinds(ops), ["skip"]);
+  assert.equal(only(ops, "skip")[0].reason, "has-attachments");
+});
+
+test("a conflict on a note with attachments is reported, not resolved destructively", () => {
+  const ops = plan(
+    [note("n1", "notedude version")],
+    [keep("notes/k1", "keep version", { hasAttachments: true })],
+    [mapping("n1", "notes/k1", "base")]
+  );
+  assert.deepEqual(kinds(ops), ["skip"]);
+  assert.equal(only(ops, "skip")[0].reason, "has-attachments");
+});
+
+test("attachments override --on-leave-scope=delete", () => {
+  const ops = plan(
+    [note("n1", "Buy milk #tasks-today")],
+    [keep("notes/k1", "Buy milk", { hasAttachments: true })],
+    [mapping("n1", "notes/k1", "Buy milk")],
+    "delete"
+  );
+  assert.equal(only(ops, "unlink")[0].deleteKeep, false);
+});
+
+test("a remote edit still flows into notedude when the Keep note has attachments", () => {
+  // Only pushes are dangerous; pulling from an attachment note destroys nothing.
+  const ops = plan(
+    [note("n1", "base")],
+    [keep("notes/k1", "Edited in Keep", { hasAttachments: true })],
+    [mapping("n1", "notes/k1", "base")]
+  );
+  assert.deepEqual(kinds(ops), ["update-notedude"]);
+});
+
+// ── ordering guarantees ────────────────────────────────────────────────────────
+
+test("imports are planned before pushes so a partial run never strands Keep content", () => {
+  const ops = plan(
+    [note("n2", "New local note")],
+    [keep("notes/k1", "New remote note")],
+    []
+  );
+  const importIdx = ops.findIndex((o) => o.kind === "create-notedude");
+  const pushIdx = ops.findIndex((o) => o.kind === "create-keep");
+  assert.ok(importIdx !== -1 && pushIdx !== -1);
+  assert.ok(importIdx < pushIdx, "pull operations must be planned before push operations");
+});
+
+// ── mixed workload ─────────────────────────────────────────────────────────────
+
+test("a mixed run plans each note independently", () => {
+  const ops = plan(
+    [
+      note("n1", "Unchanged"),
+      note("n2", "Locally edited"),
+      note("n3", "Untouched here"),
+      note("n4", "Brand new"),
+      note("n5", "Task note #tasks-inbox"),
+    ],
+    [
+      keep("notes/k1", "Unchanged"),
+      keep("notes/k2", "Locally edited base"),
+      keep("notes/k3", "Remotely edited"),
+      keep("notes/k9", "New in Keep"),
+    ],
+    [
+      mapping("n1", "notes/k1", "Unchanged"),
+      mapping("n2", "notes/k2", "Locally edited base"),
+      mapping("n3", "notes/k3", "Untouched here"),
+    ]
+  );
+  assert.equal(only(ops, "replace-keep").length, 1);
+  assert.equal(only(ops, "replace-keep")[0].noteId, "n2");
+  assert.equal(only(ops, "update-notedude").length, 1);
+  assert.equal(only(ops, "update-notedude")[0].noteId, "n3");
+  assert.equal(only(ops, "create-keep").length, 1);
+  assert.equal(only(ops, "create-keep")[0].noteId, "n4");
+  assert.equal(only(ops, "create-notedude").length, 1);
+  assert.equal(only(ops, "create-notedude")[0].keepName, "notes/k9");
+  assert.equal(only(ops, "conflict").length, 0);
+});
+
+test("planning is idempotent — replanning the same state yields the same plan", () => {
+  const notes = [note("n1", "Locally edited")];
+  const keeps = [keep("notes/k1", "base")];
+  const maps = [mapping("n1", "notes/k1", "base")];
+  assert.deepEqual(plan(notes, keeps, maps), plan(notes, keeps, maps));
+});

--- a/mcp/keep/plan.ts
+++ b/mcp/keep/plan.ts
@@ -1,0 +1,149 @@
+import { canonical, contentHash, fromKeep } from "./convert.ts";
+import { syncScope } from "./scope.ts";
+import type { PlanInput, SyncOp } from "./types.ts";
+
+/**
+ * The whole sync decision, as a pure function. See spec.md § Change detection.
+ *
+ * Every I/O concern lives in sync.ts; this file only diffs three inputs into a
+ * list of operations, which is what makes the awkward cases — conflicts, scope
+ * changes, the duplication loops — testable without touching a network.
+ */
+export function planSync({ notes, keepNotes, mappings, onLeaveScope }: PlanInput): SyncOp[] {
+  /** Keep → notedude. Planned first: importing is non-destructive, pushing is not. */
+  const pull: SyncOp[] = [];
+  /** notedude → Keep. */
+  const push: SyncOp[] = [];
+  /** Reports. Ordering irrelevant, so they trail the plan. */
+  const reports: SyncOp[] = [];
+
+  const notesById = new Map(notes.map((n) => [n.id, n]));
+  const keepByName = new Map(keepNotes.map((k) => [k.name, k]));
+  const mappedNoteIds = new Set(mappings.map((m) => m.noteId));
+  // Includes tombstones — see the unlink handling below for why that matters.
+  const mappedKeepNames = new Set(mappings.map((m) => m.keepName));
+
+  // ── existing pairs ───────────────────────────────────────────────────────────
+  for (const m of mappings) {
+    const note = notesById.get(m.noteId);
+    const keepNote = keepByName.get(m.keepName);
+    const liveKeep = keepNote && !keepNote.trashed ? keepNote : undefined;
+    const scope = note ? syncScope(note.content) : undefined;
+
+    // A tombstoned pair stays dormant until the note re-enters scope.
+    if (m.unlinked) {
+      if (!note || !scope?.inScope) continue;
+      const content = canonical(note.content);
+      push.push(
+        liveKeep
+          ? { kind: "replace-keep", noteId: m.noteId, keepName: m.keepName, content }
+          : { kind: "create-keep", noteId: m.noteId, content }
+      );
+      continue;
+    }
+
+    // The note is gone, or no longer belongs in Keep.
+    if (!note || !scope?.inScope) {
+      // Outgrowing Keep's cap is not leaving scope — the pair is still ours, the
+      // note just cannot fit right now. Unlinking here would orphan a live note.
+      if (note && scope?.reason === "too-large") {
+        reports.push({ kind: "skip", noteId: m.noteId, keepName: m.keepName, reason: "too-large" });
+        continue;
+      }
+      // Deleting is opt-in: notes.delete is irreversible, so the safe default
+      // leaves the Keep note in place and remembers not to re-import it.
+      push.push({
+        kind: "unlink",
+        noteId: m.noteId,
+        keepName: m.keepName,
+        // Attachments are unrecoverable, so they override the delete policy.
+        deleteKeep: onLeaveScope === "delete" && !!liveKeep && !liveKeep.hasAttachments,
+      });
+      continue;
+    }
+
+    // Deleted or trashed in Keep → soft-archive locally, matching Shift+Y.
+    if (!liveKeep) {
+      pull.push({ kind: "archive-notedude", noteId: m.noteId, keepName: m.keepName });
+      continue;
+    }
+
+    const content = canonical(note.content);
+    const keepContent = fromKeep(liveKeep);
+    const localHash = contentHash(content);
+    const remoteHash = contentHash(keepContent);
+    const localChanged = localHash !== m.baseHash;
+    const remoteChanged = remoteHash !== m.baseHash;
+
+    if (!localChanged && !remoteChanged) continue;
+
+    if (localChanged && !remoteChanged) {
+      // Replacing means delete + recreate, and the API cannot re-upload media, so
+      // pushing over an attachment would destroy it with no way back.
+      if (liveKeep.hasAttachments) {
+        reports.push({ kind: "skip", noteId: m.noteId, keepName: m.keepName, reason: "has-attachments" });
+        continue;
+      }
+      push.push({ kind: "replace-keep", noteId: m.noteId, keepName: m.keepName, content });
+      continue;
+    }
+
+    if (!localChanged && remoteChanged) {
+      pull.push({ kind: "update-notedude", noteId: m.noteId, keepName: m.keepName, content: keepContent });
+      continue;
+    }
+
+    // Both sides moved. Landing on the same text is convergence, not a conflict —
+    // there is nothing to write, only a stale merge base to advance.
+    if (localHash === remoteHash) {
+      push.push({ kind: "rebase", noteId: m.noteId, keepName: m.keepName, content });
+      continue;
+    }
+
+    // Resolving a conflict also replaces the Keep note. Rather than destroy an
+    // attachment, leave both sides untouched and report until a human resolves it.
+    if (liveKeep.hasAttachments) {
+      reports.push({ kind: "skip", noteId: m.noteId, keepName: m.keepName, reason: "has-attachments" });
+      continue;
+    }
+
+    push.push({
+      kind: "conflict",
+      noteId: m.noteId,
+      keepName: m.keepName,
+      content,
+      conflictContent: keepContent,
+    });
+  }
+
+  // ── notes with no Keep counterpart ───────────────────────────────────────────
+  for (const n of notes) {
+    if (mappedNoteIds.has(n.id)) continue;
+    const scope = syncScope(n.content);
+    if (scope.inScope) {
+      push.push({ kind: "create-keep", noteId: n.id, content: canonical(n.content) });
+    } else if (scope.reason === "too-large") {
+      // Only genuine failures are reported; a #tasks-* note not syncing is by design.
+      reports.push({ kind: "skip", noteId: n.id, reason: "too-large" });
+    }
+  }
+
+  // ── Keep notes with no notedude counterpart ──────────────────────────────────
+  for (const k of keepNotes) {
+    // Tombstones are consulted here. Skipping this check lets an unlinked Keep
+    // note be re-imported as a new note, which unlinks again next run, which
+    // re-imports again — the pair multiplies on every sync.
+    if (mappedKeepNames.has(k.name) || k.trashed) continue;
+    const content = fromKeep(k);
+    const scope = syncScope(content);
+    if (scope.inScope) {
+      pull.push({ kind: "create-notedude", keepName: k.name, content });
+    } else if (scope.reason === "too-large") {
+      reports.push({ kind: "skip", keepName: k.name, reason: "too-large" });
+    }
+    // A Keep note that would land out of scope (e.g. it contains #tasks-today) is
+    // deliberately not imported: it would unlink on the next run and orphan itself.
+  }
+
+  return [...pull, ...push, ...reports];
+}

--- a/mcp/keep/scope.test.ts
+++ b/mcp/keep/scope.test.ts
@@ -1,0 +1,83 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { KEEP_BODY_MAX, KEEP_TITLE_MAX, syncScope } from "./scope.ts";
+
+test("plain notes are in scope", () => {
+  assert.equal(syncScope("Buy milk").inScope, true);
+  assert.equal(syncScope("Shopping\nmilk, eggs").inScope, true);
+});
+
+test("notes tagged #tasks-* are out of scope — they belong to Google Tasks (#138)", () => {
+  for (const tag of ["#tasks-inbox", "#tasks-today", "#tasks-nearterm", "#tasks-longterm", "#tasks-done"]) {
+    const r = syncScope(`Call the vet ${tag}`);
+    assert.equal(r.inScope, false, `${tag} should be out of scope`);
+    assert.equal(r.reason, "task-tagged");
+  }
+});
+
+test("a task tag anywhere in the content takes the note out of scope", () => {
+  assert.equal(syncScope("line one\nline two #tasks-today\nline three").inScope, false);
+});
+
+test("bare #tasks is not a task tag, matching the app's /#tasks-[\\w-]+/", () => {
+  // The app's TASK_TAG_RE requires at least one character after the hyphen.
+  // Documented in spec.md so the rule is a decision, not an accident.
+  assert.equal(syncScope("Groceries #tasks").inScope, true);
+});
+
+test("#tasks- with no suffix is likewise not a task tag", () => {
+  assert.equal(syncScope("Groceries #tasks-").inScope, true);
+});
+
+test("tag matching is case-insensitive", () => {
+  assert.equal(syncScope("Call the vet #TASKS-Today").inScope, false);
+});
+
+test("a tag that merely starts with the same letters is not a task tag", () => {
+  assert.equal(syncScope("Note #tasksomething").inScope, true);
+  assert.equal(syncScope("Note #taskstoday").inScope, true);
+});
+
+test("archived notes are out of scope", () => {
+  const r = syncScope("Old note #archived");
+  assert.equal(r.inScope, false);
+  assert.equal(r.reason, "archived");
+});
+
+test("conflict copies are out of scope so they are never pushed back to Keep", () => {
+  const r = syncScope("Keep's version #sync-conflict");
+  assert.equal(r.inScope, false);
+  assert.equal(r.reason, "conflict-copy");
+});
+
+test("blank notes are out of scope", () => {
+  assert.equal(syncScope("").inScope, false);
+  assert.equal(syncScope("   \n  ").inScope, false);
+  assert.equal(syncScope("").reason, "blank");
+});
+
+test("a note whose title exceeds Keep's cap is out of scope and reported", () => {
+  const r = syncScope("t".repeat(KEEP_TITLE_MAX + 1));
+  assert.equal(r.inScope, false);
+  assert.equal(r.reason, "too-large");
+});
+
+test("a title exactly at Keep's cap is allowed", () => {
+  assert.equal(syncScope("t".repeat(KEEP_TITLE_MAX)).inScope, true);
+});
+
+test("a note whose body exceeds Keep's cap is out of scope and reported, never truncated", () => {
+  const r = syncScope("Title\n" + "b".repeat(KEEP_BODY_MAX + 1));
+  assert.equal(r.inScope, false);
+  assert.equal(r.reason, "too-large");
+});
+
+test("a body exactly at Keep's cap is allowed", () => {
+  assert.equal(syncScope("Title\n" + "b".repeat(KEEP_BODY_MAX)).inScope, true);
+});
+
+test("size is the last check, so a task-tagged oversized note reports task-tagged", () => {
+  // Reporting "too-large" for a note that was never meant to sync would be noise.
+  const r = syncScope("#tasks-today " + "b".repeat(KEEP_BODY_MAX + 1));
+  assert.equal(r.reason, "task-tagged");
+});

--- a/mcp/keep/scope.ts
+++ b/mcp/keep/scope.ts
@@ -1,0 +1,48 @@
+import { toKeep } from "./convert.ts";
+
+/**
+ * Which notes sync to Keep. See spec.md § What syncs.
+ *
+ * The rule the feature exists to enforce: everything *except* `#tasks-*` notes,
+ * which belong to Google Tasks (#138).
+ */
+
+/** Keep caps the title at 1,000 characters. */
+export const KEEP_TITLE_MAX = 1000;
+/** Keep caps the text body at 20,000 characters. notedude allows 100,000. */
+export const KEEP_BODY_MAX = 20000;
+
+/**
+ * Task tags, matched exactly as the app's `TASK_TAG_RE` does — at least one
+ * character must follow the hyphen, so a bare `#tasks` is not a task tag.
+ */
+const TASK_TAG_RE = /#tasks-[\w-]+/i;
+const ARCHIVED_RE = /#archived(?=[\s,.]|$)/i;
+const CONFLICT_RE = /#sync-conflict(?=[\s,.]|$)/i;
+
+export type ScopeReason = "task-tagged" | "archived" | "conflict-copy" | "blank" | "too-large";
+
+export interface ScopeResult {
+  inScope: boolean;
+  reason?: ScopeReason;
+}
+
+/**
+ * Decide whether `content` may live in Keep.
+ *
+ * Order matters: the tag checks come first so an oversized task note reports
+ * "task-tagged" rather than "too-large" — it was never going to sync, and
+ * reporting a size problem for it would be noise.
+ */
+export function syncScope(content: string): ScopeResult {
+  if (TASK_TAG_RE.test(content)) return { inScope: false, reason: "task-tagged" };
+  if (ARCHIVED_RE.test(content)) return { inScope: false, reason: "archived" };
+  if (CONFLICT_RE.test(content)) return { inScope: false, reason: "conflict-copy" };
+  if (content.trim() === "") return { inScope: false, reason: "blank" };
+
+  const { title, body } = toKeep(content);
+  if (title.length > KEEP_TITLE_MAX || body.length > KEEP_BODY_MAX) {
+    return { inScope: false, reason: "too-large" };
+  }
+  return { inScope: true };
+}

--- a/mcp/keep/store.ts
+++ b/mcp/keep/store.ts
@@ -1,0 +1,111 @@
+import type admin from "firebase-admin";
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
+import type { NotedudeNote, SyncMapping } from "./types.ts";
+
+/**
+ * notedude's side of the sync: notes at `users/{uid}/notes` and sync mappings at
+ * `users/{uid}/keepSync`.
+ *
+ * The mapping collection is reachable only through the Admin SDK — the Firestore
+ * rules allow `users/{userId}/notes/{noteId}` and nothing else, so the default
+ * deny already keeps browser clients out of it.
+ */
+export class NotedudeStore {
+  constructor(
+    private readonly db: admin.firestore.Firestore,
+    private readonly uid: string
+  ) {}
+
+  private notesCol() {
+    return this.db.collection("users").doc(this.uid).collection("notes");
+  }
+
+  private mappingCol() {
+    return this.db.collection("users").doc(this.uid).collection("keepSync");
+  }
+
+  async listNotes(): Promise<NotedudeNote[]> {
+    const snap = await this.notesCol().get();
+    return snap.docs.map((d) => {
+      const data = d.data();
+      return {
+        id: d.id,
+        content: data.content ?? "",
+        updatedAt: data.updatedAt instanceof Timestamp ? data.updatedAt.toMillis() : data.updatedAt ?? 0,
+      };
+    });
+  }
+
+  async listMappings(): Promise<SyncMapping[]> {
+    const snap = await this.mappingCol().get();
+    return snap.docs.map((d) => {
+      const data = d.data();
+      return {
+        noteId: d.id,
+        keepName: data.keepName ?? "",
+        baseHash: data.baseHash ?? "",
+        lastSyncedAt: data.lastSyncedAt ?? 0,
+        unlinked: data.unlinked === true,
+        keepDeleted: data.keepDeleted === true,
+      };
+    });
+  }
+
+  /** Create a note. Fields match the security-rules whitelist so the app reads it normally. */
+  async createNote(content: string): Promise<string> {
+    const ref = this.notesCol().doc();
+    await ref.set({
+      content,
+      pinned: false,
+      tagPinned: false,
+      createdAt: Date.now(),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    return ref.id;
+  }
+
+  async updateNote(noteId: string, content: string): Promise<void> {
+    await this.notesCol().doc(noteId).update({
+      content,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  }
+
+  /**
+   * Soft-archive by appending `#archived`, exactly as `Shift+Y` and the MCP
+   * `delete_note` tool do. Idempotent. Notes are never hard-deleted by sync.
+   */
+  async archiveNote(noteId: string): Promise<void> {
+    const ref = this.notesCol().doc(noteId);
+    const snap = await ref.get();
+    if (!snap.exists) return;
+    const current: string = snap.data()?.content ?? "";
+    if (/#archived(?=[\s,.]|$)/i.test(current)) return;
+    const sep = current.endsWith("\n") || current === "" ? "" : " ";
+    await ref.update({
+      content: current + sep + "#archived",
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+  }
+
+  async saveMapping(m: SyncMapping): Promise<void> {
+    await this.mappingCol().doc(m.noteId).set({
+      keepName: m.keepName,
+      baseHash: m.baseHash,
+      lastSyncedAt: m.lastSyncedAt,
+      unlinked: m.unlinked ?? false,
+      keepDeleted: m.keepDeleted ?? false,
+    });
+  }
+
+  /**
+   * Tombstone a mapping. The record is kept, not deleted: it is what stops the
+   * orphaned Keep note being re-imported as a new note on the next run.
+   */
+  async markUnlinked(noteId: string, keepDeleted: boolean): Promise<void> {
+    await this.mappingCol().doc(noteId).set(
+      { unlinked: true, keepDeleted, lastSyncedAt: Date.now() },
+      { merge: true }
+    );
+  }
+}

--- a/mcp/keep/sync.ts
+++ b/mcp/keep/sync.ts
@@ -1,0 +1,88 @@
+import { applyOps, type ApplyResult } from "./apply.ts";
+import { planSync } from "./plan.ts";
+import type { KeepClient, LeaveScopePolicy, NoteStore, SyncOp } from "./types.ts";
+
+/** Orchestrates a run: read both sides, plan, then (unless dry) apply. */
+
+export interface SyncOptions {
+  onLeaveScope?: LeaveScopePolicy;
+  dryRun?: boolean;
+}
+
+export interface SyncReport {
+  dryRun: boolean;
+  plan: SyncOp[];
+  result?: ApplyResult;
+}
+
+export async function runSync(
+  keep: KeepClient,
+  store: NoteStore,
+  { onLeaveScope = "unlink", dryRun = false }: SyncOptions = {}
+): Promise<SyncReport> {
+  const [notes, keepNotes, mappings] = await Promise.all([
+    store.listNotes(),
+    keep.listNotes(),
+    store.listMappings(),
+  ]);
+
+  const plan = planSync({ notes, keepNotes, mappings, onLeaveScope });
+  if (dryRun) return { dryRun: true, plan };
+
+  return { dryRun: false, plan, result: await applyOps(plan, keep, store) };
+}
+
+/** One line per operation, in plain language. */
+export function describeOp(op: SyncOp): string {
+  switch (op.kind) {
+    case "create-keep":
+      return `create in Keep      ${op.noteId}`;
+    case "replace-keep":
+      return `replace in Keep     ${op.noteId} (${op.keepName} → new note)`;
+    case "create-notedude":
+      return `import from Keep    ${op.keepName}`;
+    case "update-notedude":
+      return `update in notedude  ${op.noteId}`;
+    case "conflict":
+      return `CONFLICT            ${op.noteId} — notedude wins, Keep's copy saved as #sync-conflict`;
+    case "rebase":
+      return `converged           ${op.noteId} (no writes, merge base advanced)`;
+    case "archive-notedude":
+      return `archive in notedude ${op.noteId} (deleted in Keep)`;
+    case "unlink":
+      return `unlink              ${op.noteId}${op.deleteKeep ? ` and delete ${op.keepName}` : " (Keep note left in place)"}`;
+    case "skip":
+      return `skipped             ${op.noteId ?? op.keepName} — ${op.reason}`;
+  }
+}
+
+/** Human-readable summary, used by both the MCP tool and the CLI. */
+export function formatReport(report: SyncReport): string {
+  const lines: string[] = [];
+
+  if (report.plan.length === 0) {
+    return report.dryRun ? "Dry run: nothing to sync." : "Nothing to sync — both sides are up to date.";
+  }
+
+  lines.push(report.dryRun ? `Dry run — ${report.plan.length} operation(s) planned:` : `${report.plan.length} operation(s):`);
+  for (const op of report.plan) lines.push(`  ${describeOp(op)}`);
+
+  if (report.result) {
+    const { applied, failed, skipped } = report.result;
+    lines.push("");
+    lines.push(`Applied ${applied.length}, skipped ${skipped.length}, failed ${failed.length}.`);
+    for (const f of failed) lines.push(`  FAILED  ${describeOp(f.op)} — ${f.error}`);
+
+    if (report.plan.some((o) => o.kind === "conflict")) {
+      lines.push("");
+      lines.push("Conflicts were saved as #sync-conflict notes — search that tag to resolve them.");
+    }
+    if (skipped.some((o) => o.kind === "skip" && o.reason === "has-attachments")) {
+      lines.push("");
+      lines.push("Notes with Keep attachments were left untouched: the API cannot re-upload media,");
+      lines.push("so replacing them would destroy the attachment. Edit those in Keep directly.");
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/mcp/keep/types.ts
+++ b/mcp/keep/types.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared types for Google Keep sync. See spec.md § Google Keep Sync and #142.
+ *
+ * The Keep API has no update method and its delete is irreversible, so every type
+ * here is shaped around "create the replacement before removing the original".
+ */
+
+/** A notedude note, as stored at `users/{uid}/notes/{noteId}`. */
+export interface NotedudeNote {
+  id: string;
+  content: string;
+  updatedAt: number;
+}
+
+/**
+ * A Keep note, normalised. `body` is always plain text — a checklist
+ * (`body.list`) is rendered to markdown checkboxes when read.
+ */
+export interface KeepNote {
+  /** Resource name, e.g. `notes/abc123`. */
+  name: string;
+  title: string;
+  body: string;
+  updateTime: number;
+  trashed: boolean;
+  /** True when the Keep note is a checklist, which cannot be edited in place. */
+  isList?: boolean;
+  /**
+   * True when the Keep note carries attachments. The API can download media but
+   * offers no way to upload it, so a replaced note's attachments are gone for
+   * good. Such notes are never replaced or deleted — see `planSync`.
+   */
+  hasAttachments?: boolean;
+}
+
+/**
+ * The persisted link between a notedude note and its Keep counterpart, at
+ * `users/{uid}/keepSync/{noteId}`.
+ *
+ * Unlinked records are retained as **tombstones** rather than deleted. Without
+ * them, a note that leaves sync scope would have its Keep counterpart re-imported
+ * as a brand-new notedude note on the next run, duplicating it forever.
+ */
+export interface SyncMapping {
+  noteId: string;
+  keepName: string;
+  /** Hash of the canonical content at last successful sync — the merge base. */
+  baseHash: string;
+  lastSyncedAt: number;
+  /** Tombstone: the pair no longer syncs, but the Keep note must not be re-imported. */
+  unlinked?: boolean;
+  /** Set when the Keep note was deleted on unlink (`--on-leave-scope=delete`). */
+  keepDeleted?: boolean;
+}
+
+/** What to do with the Keep note when a notedude note leaves sync scope. */
+export type LeaveScopePolicy = "unlink" | "delete";
+
+/**
+ * A single planned change. `planSync` returns these; `applyOps` executes them.
+ * Keeping planning pure is what makes the whole diff testable without network.
+ */
+export type SyncOp =
+  /** New in notedude → create in Keep. */
+  | { kind: "create-keep"; noteId: string; content: string }
+  /** Edited in notedude → create the replacement, then delete `keepName`. */
+  | { kind: "replace-keep"; noteId: string; keepName: string; content: string }
+  /** New in Keep → create in notedude. */
+  | { kind: "create-notedude"; keepName: string; content: string }
+  /** Edited in Keep → update the notedude note. */
+  | { kind: "update-notedude"; noteId: string; keepName: string; content: string }
+  /**
+   * Both sides changed. `content` (notedude's) wins and is pushed to Keep;
+   * `conflictContent` (Keep's) is preserved as a new `#sync-conflict` note,
+   * written **before** the Keep note is replaced.
+   */
+  | { kind: "conflict"; noteId: string; keepName: string; content: string; conflictContent: string }
+  /** Both sides changed to the same content — no writes, just move the merge base. */
+  | { kind: "rebase"; noteId: string; keepName: string; content: string }
+  /** Deleted or trashed in Keep → soft-archive the notedude note. */
+  | { kind: "archive-notedude"; noteId: string; keepName: string }
+  /** Left sync scope → tombstone the mapping, optionally deleting the Keep note. */
+  | { kind: "unlink"; noteId: string; keepName: string; deleteKeep: boolean }
+  /** Reported, never silent: something the user should know was not synced. */
+  | { kind: "skip"; noteId?: string; keepName?: string; reason: string };
+
+/** Everything `planSync` needs. Pure data — no clients, no I/O. */
+export interface PlanInput {
+  notes: NotedudeNote[];
+  keepNotes: KeepNote[];
+  mappings: SyncMapping[];
+  onLeaveScope: LeaveScopePolicy;
+}
+
+/** The subset of the Keep API this feature uses. Implemented for real and faked in tests. */
+export interface KeepClient {
+  listNotes(): Promise<KeepNote[]>;
+  createNote(title: string, body: string): Promise<KeepNote>;
+  deleteNote(name: string): Promise<void>;
+}
+
+/** notedude's side of sync. `NotedudeStore` implements it; tests fake it. */
+export interface NoteStore {
+  listNotes(): Promise<NotedudeNote[]>;
+  listMappings(): Promise<SyncMapping[]>;
+  createNote(content: string): Promise<string>;
+  updateNote(noteId: string, content: string): Promise<void>;
+  archiveNote(noteId: string): Promise<void>;
+  saveMapping(m: SyncMapping): Promise<void>;
+  markUnlinked(noteId: string, keepDeleted: boolean): Promise<void>;
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -7,11 +7,15 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "tsx index.ts"
+    "dev": "tsx index.ts",
+    "test": "node --test \"keep/*.test.ts\"",
+    "typecheck": "tsc --noEmit",
+    "sync:keep": "node keep/cli.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
     "firebase-admin": "^13.4.0",
+    "google-auth-library": "^10.6.2",
     "dotenv": "^16.4.7"
   },
   "devDependencies": {

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -7,7 +7,10 @@
     "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true
   },
-  "include": ["index.ts"]
+  "include": ["index.ts", "keep/**/*.ts"],
+  "exclude": ["keep/**/*.test.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "test": "playwright test",
+    "test:unit": "node --test \"mcp/keep/*.test.ts\"",
     "dev": "next dev --webpack",
     "build": "next build --webpack",
     "deploy": "npm run build && firebase deploy --only hosting",

--- a/spec.md
+++ b/spec.md
@@ -487,3 +487,80 @@ Firebase Hosting serves these response headers on all routes (configured in `fir
 
 ### MCP archive consistency
 - The MCP `delete_note` tool performs a **soft archive** consistent with the app: it appends a `#archived` tag to the note's content (matching `Shift+Y`), rather than setting a separate field. This ensures notes archived via MCP are hidden in the app's Idle State exactly like notes archived in-app. It is idempotent — a note already tagged `#archived` is left unchanged.
+
+## Google Keep Sync
+
+Two-way sync between notedude notes and Google Keep. See #142. The complement of #138, which syncs `#tasks-*` notes to Google Tasks — a note belongs to exactly one of the two systems.
+
+Sync runs **server-side in `mcp/`**. The web app is a static export with no server runtime, and the Keep API neither permits browser origins nor tolerates a client-side credential, so no part of sync runs in the browser.
+
+### What syncs
+
+A notedude note syncs to Keep if and only if **all** of these hold:
+
+| Condition | Rationale |
+|-----------|-----------|
+| Carries no `#tasks-*` tag | Task notes belong to Google Tasks (#138) |
+| Not tagged `#archived` | Archived notes are not re-published to Keep |
+| Not tagged `#sync-conflict` | Conflict copies are local resolution artifacts (below) |
+| Content is not blank | Matches the app's discard-empty-note rule |
+| Fits Keep's size caps | Title ≤ 1,000 and body ≤ 20,000 characters |
+
+- A **task tag** is matched with `/#tasks-[\w-]+/`, the same expression the app uses. A bare `#tasks` is therefore *not* a task tag and such a note **does** sync.
+- Tags are otherwise tokenised as `/#[\w-]+/`, matching the app.
+- A note exceeding Keep's caps is **skipped and reported** — never truncated. notedude permits 100,000 characters, Keep 20,000, so this is reachable in normal use.
+
+### Constraints imposed by the Keep API
+
+The official [Keep API](https://developers.google.com/workspace/keep/api/guides) is **Workspace-only** — it is not available to personal `@gmail.com` accounts, and access requires a service account with **domain-wide delegation** impersonating the note owner. Beyond that, two limits shape the whole design:
+
+1. **There is no update method.** The `notes` resource exposes only `create`, `get`, `list` and `delete`. An existing Keep note cannot be edited through the API.
+2. **`notes.delete` is permanent.** It "removes the resource immediately and cannot be undone", and any collaborators lose access.
+
+Together these mean a notedude edit reaches Keep only as **delete + recreate**. Consequently:
+
+- The replacement is always **created before the old note is deleted**. An interrupted sync therefore leaves a duplicate — recoverable — rather than a hole, which would not be.
+- Recreating mints a **new Keep note id** and **discards Keep-side metadata**: labels, reminders, collaborators, colour and pin state. This is a property of the API, not of this implementation.
+
+### Change detection
+
+Each synced pair has a mapping record at `users/{uid}/keepSync/{noteId}` holding the notedude id, the Keep resource `name`, and a hash of the content at last successful sync. Client access is denied by the default-deny Firestore rules; only the Admin SDK in `mcp/` reads or writes it.
+
+The stored hash is the **three-way merge base**. Each run compares it against the current notedude content and the current Keep content, so each side is independently classified as changed or unchanged:
+
+| notedude | Keep | Action |
+|----------|------|--------|
+| unchanged | unchanged | nothing |
+| changed | unchanged | replace the Keep note (create, then delete) |
+| unchanged | changed | update the notedude note |
+| changed | changed | **conflict** — see below |
+
+Hashes are taken over the **canonical** form, defined as `fromKeep(toKeep(content))`. Round-tripping through Keep's `{title, body}` shape is lossy for trailing whitespace, and hashing the canonical form stops that loss from being misread as a change on every run.
+
+### Conflict resolution — nothing is destroyed
+
+When both sides changed since the last sync, notedude's version wins the mapping and is pushed to Keep. The Keep version is **not** discarded: it is written to a **new notedude note tagged `#sync-conflict`** for the user to resolve by hand.
+
+The conflict note is created **before** the Keep note is replaced, so the losing content is durably stored before the only remaining copy is deleted. This ordering is what makes an otherwise-destructive operation safe, and is chosen deliberately in light of #75 and #76.
+
+### Deletion and leaving scope
+
+Deletions are never mirrored destructively by default:
+
+- **Deleted in Keep** → the notedude note is **archived** (`#archived` appended), matching the app's soft-delete convention. It is never hard-deleted.
+- **Left scope in notedude** — gained a `#tasks-*` tag, was archived, or the document was removed → the mapping is **unlinked and the Keep note is left in place**. Because `notes.delete` is irreversible, deleting is opt-in via `--on-leave-scope=delete` rather than the default.
+
+### Content mapping
+
+| notedude | Keep |
+|----------|------|
+| First line of `content` | `title` |
+| Remaining lines | `body.text.text` |
+
+A Keep **checklist** (`body.list`) imports as markdown checkboxes (`- [ ]` / `- [x]`). Because notedude stores plain text and the API cannot update a note in place, a checklist that is later edited in notedude is recreated as a **text** note — round-tripping degrades it. Checklists that are only read are left untouched.
+
+### Running it
+
+- MCP tool `sync_keep` runs a sync on demand and reports the plan and its outcome.
+- `npm run sync:keep` runs the same from the CLI, for cron or launchd.
+- `--dry-run` prints the planned operations without executing any of them.

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -8,6 +8,7 @@ import {
   memoryLocalCache,
   doc,
   setDoc,
+  getDoc,
 } from "firebase/firestore";
 
 const firebaseConfig = {
@@ -50,6 +51,27 @@ if (useEmulator) {
       if (!user) return { ok: false, code: "no-current-user" };
       try {
         await setDoc(doc(db, "users", user.uid, "notes", noteId), data);
+        return { ok: true };
+      } catch (e) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return { ok: false, code: (e as any)?.code ?? String(e) };
+      }
+    };
+    // Raw read/write at an arbitrary path beneath the signed-in user's document.
+    // Unlike __testWriteNote this is not pinned to `notes`, so it can exercise the
+    // rules for collections the browser is never supposed to reach — notably the
+    // server-only `keepSync` mappings (#142). `segments` is [collection, docId, ...].
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__testUserPath = async (
+      segments: string[],
+      data?: Record<string, unknown>
+    ) => {
+      const user = auth.currentUser;
+      if (!user) return { ok: false, code: "no-current-user" };
+      try {
+        const ref = doc(db, "users", user.uid, ...segments);
+        if (data === undefined) await getDoc(ref);
+        else await setDoc(ref, data);
         return { ok: true };
       } catch (e) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Closes #142. Complement of #138 (`#tasks-*` → Google Tasks): a note belongs to exactly one of the two systems.

Syncs every note **not** tagged `#tasks-*` with Google Keep, in both directions. Runs server-side in `mcp/` — the web app is a static export with no server runtime, and the Keep API neither permits browser origins nor tolerates a client-side credential.

## Before reviewing: two API limits drive everything here

I verified these against the API reference before designing:

1. **There is no update method.** The `notes` resource exposes only `create`, `get`, `list`, `delete`. An existing Keep note cannot be edited. ([open request](https://issuetracker.google.com/issues/365814219))
2. **`notes.delete` is permanent** — "removes the resource immediately and cannot be undone", and collaborators lose access.

So propagating a notedude edit to Keep means **delete + recreate**, which mints a new Keep note id and **loses Keep-side labels, reminders, collaborators, colour and pin state**. That is the API, not this implementation. Also worth knowing up front: **the Keep API is Workspace-only** — it does not work with personal `@gmail.com` accounts, and needs domain-wide delegation set up in the admin console.

## How the destructive parts are made safe

| Guarantee | Why |
|---|---|
| Replacement created, and mapping repointed, **before** the old note is deleted | An interrupted run leaves a duplicate (recoverable), never a hole (not) |
| Conflict: Keep's losing version written to a `#sync-conflict` note **before** the note holding it is destroyed | Nothing is silently discarded — chosen given #75/#76 |
| Deleted in Keep → notedude note **archived**, never hard-deleted | Matches `Shift+Y` and the MCP `delete_note` convention |
| Leaving scope tombstones the mapping and **leaves the Keep note in place** | Deleting is opt-in via `--on-leave-scope=delete` |
| Keep notes with attachments are never replaced or deleted | The API can download media but cannot upload it — the attachment would be unrecoverable |
| Notes over Keep's 20,000-char cap are skipped and reported | Never truncated; notedude allows 100,000 |

## Change detection

Mapping state at `users/{uid}/keepSync/{noteId}` stores a hash of the content at last sync as a **three-way merge base**, so each side is classified as changed independently. Hashes are taken over the canonical (post-round-trip) form — otherwise a trailing newline reads as a local edit on every single run.

Unlinked mappings are kept as **tombstones**, not deleted. Without them an orphaned Keep note gets re-imported as a new note, unlinks again next run, and **the pair multiplies on every sync**. The same reasoning blocks importing a Keep note whose content would land out of scope. Both loops have regression tests.

## Testing

`planSync` is a pure function over `(notes, keepNotes, mappings)`, so every awkward case is tested without a network — **79 tests**, all passing. They use `node --test` with Node's native type-stripping, so **no new dev dependency**. The apply tests assert on a call log, since ordering is the only thing standing between a sync and permanent data loss.

Unit tests now run in CI ahead of the browser suite (they need no `npm ci`).

```
npm run test:unit     # 79/79
cd mcp && npm run typecheck
```

## Not verified end-to-end

I could not exercise this against a live Keep account — it needs a Workspace domain with domain-wide delegation, which I have no access to. The planner, apply ordering, scope rules and config are covered by unit tests; the REST calls in `client.ts` are written to the documented API but unexercised. **Please run `npm run sync:keep -- --dry-run` first** — it prints the plan and touches nothing.

Setup instructions are in `mcp/README.md` § Google Keep sync; spec.md § Google Keep Sync documents the rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)