### PR TITLE
Extract @notedude/ui component library (#141)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ todude.md
 open-dev.mjs
 firestore-debug.log
 src/.!30593!.DS_Store
+packages/*/dist/
+

--- a/e2e/ui-gallery.spec.ts
+++ b/e2e/ui-gallery.spec.ts
@@ -1,0 +1,249 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Contract tests for @notedude/ui, driven through the gallery route at /test/ui.
+ *
+ * These cover what the library promises independently of the app: that every component
+ * renders, that colours come from the active theme rather than being baked in, and that the
+ * test ids the app's own suite depends on are emitted by the library now that the markup
+ * lives here. The app-level suite in app.spec.ts remains the behavioural gate.
+ */
+
+const section = (page: Page, name: string) => page.getByTestId(`gallery-${name}`);
+
+/** Resolved background of an element, as the browser computes it. */
+async function bgOf(page: Page, testId: string): Promise<string> {
+  return page
+    .getByTestId(testId)
+    .first()
+    .evaluate((el) => getComputedStyle(el as HTMLElement).backgroundColor);
+}
+
+async function colorOf(page: Page, testId: string): Promise<string> {
+  return page
+    .getByTestId(testId)
+    .first()
+    .evaluate((el) => getComputedStyle(el as HTMLElement).color);
+}
+
+test.describe("@notedude/ui gallery", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/test/ui");
+    await expect(page.getByTestId("gallery")).toBeVisible();
+  });
+
+  test.describe("every component renders", () => {
+    const names = [
+      "buttons",
+      "rule",
+      "divider",
+      "searchbar",
+      "tag-dropdown-search",
+      "tag-dropdown-editor",
+      "note-list",
+      "note-content",
+      "note-editor",
+      "help-overlay",
+      "task-move-dialog",
+      "mobile-toolbar",
+      "footer",
+      "account-header",
+      "login-screen",
+      "loading-screen",
+    ];
+
+    for (const name of names) {
+      test(`${name} is present`, async ({ page }) => {
+        await expect(section(page, name)).toBeVisible();
+      });
+    }
+  });
+
+  test.describe("test ids the app suite depends on", () => {
+    test("NoteList emits list-pane, note-item and its two lines", async ({ page }) => {
+      const list = section(page, "note-list");
+      await expect(list.getByTestId("list-pane")).toBeVisible();
+      await expect(list.getByTestId("note-item").first()).toBeVisible();
+      await expect(list.getByTestId("note-item-title").first()).toBeVisible();
+      await expect(list.getByTestId("note-item-meta").first()).toBeVisible();
+    });
+
+    test("NoteList emits archived-divider when archived notes are present", async ({ page }) => {
+      await expect(section(page, "note-list").getByTestId("archived-divider")).toBeVisible();
+    });
+
+    test("search TagDropdown emits the unprefixed ids", async ({ page }) => {
+      const d = section(page, "tag-dropdown-search");
+      await expect(d.getByTestId("tag-dropdown")).toBeVisible();
+      await expect(d.getByTestId("tag-item").first()).toBeVisible();
+      await expect(d.getByTestId("tag-separator")).toBeVisible();
+    });
+
+    test("editor TagDropdown emits the editor-prefixed ids", async ({ page }) => {
+      const d = section(page, "tag-dropdown-editor");
+      await expect(d.getByTestId("editor-tag-dropdown")).toBeVisible();
+      await expect(d.getByTestId("editor-tag-item").first()).toBeVisible();
+      await expect(d.getByTestId("editor-tag-separator")).toBeVisible();
+    });
+
+    test("editor TagDropdown does not emit the search ids", async ({ page }) => {
+      await expect(section(page, "tag-dropdown-editor").getByTestId("tag-dropdown")).toHaveCount(0);
+    });
+
+    test("overlays and chrome keep their ids", async ({ page }) => {
+      await expect(section(page, "help-overlay").getByTestId("help-overlay")).toBeVisible();
+      await expect(
+        section(page, "task-move-dialog").getByTestId("task-move-overlay")
+      ).toBeVisible();
+      await expect(
+        section(page, "task-move-dialog").getByTestId("task-move-item").first()
+      ).toBeVisible();
+      await expect(section(page, "mobile-toolbar").getByTestId("mobile-toolbar")).toBeVisible();
+      await expect(section(page, "searchbar").getByTestId("top-pane")).toBeVisible();
+      await expect(section(page, "divider").getByTestId("divider")).toBeVisible();
+      await expect(section(page, "account-header").getByTestId("account-header")).toBeVisible();
+      await expect(section(page, "login-screen").getByTestId("login-screen")).toBeVisible();
+      await expect(section(page, "note-content").getByTestId("content-pane")).toBeVisible();
+    });
+  });
+
+  test.describe("selection state", () => {
+    test("the selected note row is marked and the others are not", async ({ page }) => {
+      const items = section(page, "note-list").getByTestId("note-item");
+      await expect(items.nth(0)).toHaveAttribute("data-selected", "true");
+      await expect(items.nth(1)).toHaveAttribute("data-selected", "false");
+    });
+
+    test("pin state is exposed on the row", async ({ page }) => {
+      const items = section(page, "note-list").getByTestId("note-item");
+      await expect(items.nth(0)).toHaveAttribute("data-pinned", "true");
+      await expect(items.nth(0)).toHaveAttribute("data-tagpinned", "false");
+      await expect(items.nth(1)).toHaveAttribute("data-tagpinned", "true");
+    });
+
+    test("archived rows are marked archived", async ({ page }) => {
+      const list = section(page, "note-list");
+      await expect(list.getByTestId("note-item").last()).toHaveAttribute("data-archived", "true");
+    });
+
+    test("the highlighted tag row is marked selected", async ({ page }) => {
+      const items = section(page, "tag-dropdown-search").getByTestId("tag-item");
+      await expect(items.nth(0)).toHaveAttribute("data-selected", "true");
+      await expect(items.nth(1)).toHaveAttribute("data-selected", "false");
+    });
+  });
+
+  // The gallery resolves ?theme= after mount (see the route's comment), so these poll
+  // rather than reading once.
+  test.describe("theming", () => {
+    test("dark is the default canvas", async ({ page }) => {
+      // tokens.colors.bg.app.dark === #1a1a1a
+      await expect.poll(() => bgOf(page, "gallery")).toBe("rgb(26, 26, 26)");
+    });
+
+    test("the light theme repaints the canvas", async ({ page }) => {
+      await page.goto("/test/ui?theme=light");
+      // tokens.colors.bg.app.light === #ffffff
+      await expect.poll(() => bgOf(page, "gallery")).toBe("rgb(255, 255, 255)");
+    });
+
+    test("note metadata uses the muted pair, which differs per theme", async ({ page }) => {
+      // colors.fg.muted — #999999 dark, #666666 light
+      await expect.poll(() => colorOf(page, "note-item-meta")).toBe("rgb(153, 153, 153)");
+      await page.goto("/test/ui?theme=light");
+      await expect.poll(() => colorOf(page, "note-item-meta")).toBe("rgb(102, 102, 102)");
+    });
+
+    test("the footer grey is deliberately identical in both themes", async ({ page }) => {
+      // The Footer draws no test id of its own, so target it the way the app suite does.
+      const footerColor = () =>
+        page
+          .locator("text=notedude • an")
+          .evaluate((el) => getComputedStyle(el as HTMLElement).color);
+
+      // colors.fg.subtle — #888888 in both themes.
+      await expect.poll(footerColor).toBe("rgb(136, 136, 136)");
+      await page.goto("/test/ui?theme=light");
+      await expect.poll(() => bgOf(page, "gallery")).toBe("rgb(255, 255, 255)");
+      await expect.poll(footerColor).toBe("rgb(136, 136, 136)");
+    });
+
+    test("the selected row colour comes from the theme", async ({ page }) => {
+      // colors.bg.selected — #3a3a6a dark, #e0e7ff light
+      await expect.poll(() => bgOf(page, "note-item")).toBe("rgb(58, 58, 106)");
+      await page.goto("/test/ui?theme=light");
+      await expect.poll(() => bgOf(page, "note-item")).toBe("rgb(224, 231, 255)");
+    });
+  });
+
+  test.describe("typography", () => {
+    test("the library renders in the monospace face", async ({ page }) => {
+      const family = await page
+        .getByTestId("gallery")
+        .evaluate((el) => getComputedStyle(el as HTMLElement).fontFamily);
+      expect(family).toContain("Fira Code");
+    });
+
+    test("the pane divider is exactly one character wide", async ({ page }) => {
+      const width = await page
+        .getByTestId("divider")
+        .evaluate((el) => (el as HTMLElement).getBoundingClientRect().width);
+      const chWidth = await page.getByTestId("gallery").evaluate((el) => {
+        const probe = document.createElement("span");
+        probe.style.font = getComputedStyle(el as HTMLElement).font;
+        probe.textContent = "0";
+        document.body.appendChild(probe);
+        const w = probe.getBoundingClientRect().width;
+        probe.remove();
+        return w;
+      });
+      expect(width).toBeCloseTo(chWidth, 0);
+    });
+  });
+
+  test.describe("note text helpers", () => {
+    test("a note titles from its first non-blank line", async ({ page }) => {
+      await expect(
+        section(page, "note-list").getByTestId("note-item-title").nth(2)
+      ).toHaveText("buried title");
+    });
+
+    test("an untouched new note titles as New Note", async ({ page }) => {
+      await expect(
+        section(page, "note-list").getByTestId("note-item-title").nth(3)
+      ).toHaveText("New Note");
+    });
+
+    test("a bare URL in note content becomes a new-tab link", async ({ page }) => {
+      const link = section(page, "note-content").getByRole("link", { name: /example\.com/ });
+      await expect(link).toHaveAttribute("target", "_blank");
+      await expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
+  });
+
+  test.describe("interaction", () => {
+    test("clicking a note row reports the id", async ({ page }) => {
+      await section(page, "note-list").getByTestId("note-item").nth(1).click();
+      await expect(page.getByTestId("last-event")).toHaveText("select:n2");
+    });
+
+    test("clicking a search tag row reports the tag", async ({ page }) => {
+      await section(page, "tag-dropdown-search").getByTestId("tag-item").nth(1).click();
+      await expect(page.getByTestId("last-event")).toHaveText("tag:#guide");
+    });
+
+    test("the editor tag row commits on mousedown, keeping focus off the row", async ({ page }) => {
+      // The app relies on this: a click would blur the textarea before the tag is inserted.
+      await section(page, "tag-dropdown-editor")
+        .getByTestId("editor-tag-item")
+        .nth(0)
+        .dispatchEvent("mousedown");
+      await expect(page.getByTestId("last-event")).toHaveText("editor-tag:#intro");
+    });
+
+    test("a toolbar button reports its action", async ({ page }) => {
+      await section(page, "mobile-toolbar").getByTestId("mobile-compose").click();
+      await expect(page.getByTestId("last-event")).toHaveText("compose");
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "notedude2",
       "version": "1.0.0",
       "license": "ISC",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@ducanh2912/next-pwa": "^10.2.9",
         "firebase": "^12.11.0",
@@ -1602,6 +1605,448 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@firebase/ai": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.10.0.tgz",
@@ -2930,6 +3375,10 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@notedude/ui": {
+      "resolved": "packages/ui",
+      "link": true
     },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
@@ -4857,6 +5306,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -8896,6 +9387,17 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "packages/ui": {
+      "name": "@notedude/ui",
+      "version": "0.1.0",
+      "devDependencies": {
+        "esbuild": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,9 +2,15 @@
   "name": "notedude2",
   "version": "1.0.0",
   "main": "index.js",
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "test": "playwright test",
+    "build:ui": "npm run build --workspace @notedude/ui",
+    "predev": "npm run build:ui",
     "dev": "next dev --webpack",
+    "prebuild": "npm run build:ui",
     "build": "next build --webpack",
     "deploy": "npm run build && firebase deploy --only hosting",
     "deploy:staging": "npm run build && firebase hosting:channel:deploy staging --expires 30d"

--- a/packages/ui/build.mjs
+++ b/packages/ui/build.mjs
@@ -1,0 +1,17 @@
+// Builds the library to dist/ as ESM, with React left external so the app and the
+// design-system bundle share one React instance. Type declarations are emitted
+// separately by `tsc -p tsconfig.build.json` (see the "build" script).
+import { build } from "esbuild";
+
+await build({
+  entryPoints: ["src/index.ts"],
+  outfile: "dist/index.js",
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: "es2022",
+  jsx: "automatic",
+  sourcemap: true,
+  // Two React copies would break hooks; the consumer always supplies it.
+  external: ["react", "react-dom", "react/jsx-runtime"],
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@notedude/ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "notedude design system — the presentational layer shared by the app and claude.ai/design",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "node build.mjs && tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.0"
+  }
+}

--- a/packages/ui/src/AppShell.tsx
+++ b/packages/ui/src/AppShell.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "./theme";
+
+export interface AppShellProps {
+  children: React.ReactNode;
+}
+
+/**
+ * The page frame: exactly one viewport tall, never scrolling.
+ *
+ * `overflow: hidden` is what keeps the account header from being pushed off screen — a flex
+ * item's default `min-height: auto` resolves to its content's height, so without this the
+ * page grew taller than the viewport and scrolled (#124).
+ */
+export function AppShell({ children }: AppShellProps) {
+  const { c } = useTheme();
+  return (
+    <div
+      style={{
+        height: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        background: c.bg.app,
+        overflow: "hidden",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface AppSlotProps {
+  children: React.ReactNode;
+}
+
+/**
+ * The region the app itself occupies inside the shell. `minHeight: 0` lets it shrink to the
+ * space actually left over rather than being sized by its own content (#124).
+ */
+export function AppSlot({ children }: AppSlotProps) {
+  return <div style={{ flex: 1, minHeight: 0 }}>{children}</div>;
+}
+
+export interface AccountHeaderProps {
+  children: React.ReactNode;
+}
+
+/** The right-aligned identity strip above the app. Never compressed, never scrolled away. */
+export function AccountHeader({ children }: AccountHeaderProps) {
+  const { c, t } = useTheme();
+  return (
+    <div
+      data-testid="account-header"
+      style={{
+        display: "flex",
+        justifyContent: "flex-end",
+        padding: `${t.space.xs}px ${t.space.md}px`,
+        fontSize: t.fontSizes.sm,
+        fontFamily: t.fonts.mono,
+        color: c.fg.dim,
+        flexShrink: 0,
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "./theme";
+
+export type ButtonVariant = "default" | "outline" | "toolbar" | "link";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /**
+   * `default` — native button chrome; the primary sign-in action.
+   * `outline` — bordered and transparent, in muted text; the demo-mode entry point.
+   * `toolbar` — bordered and transparent, in body text, stretched; the mobile toolbar (#108).
+   * `link`    — underlined text with no box; logout, and returning from demo mode.
+   */
+  variant?: ButtonVariant;
+}
+
+/**
+ * The app's four button treatments. Every one inherits the monospace face from its container
+ * rather than restating it, so a button always matches the text around it.
+ */
+export function Button({ variant = "default", style, children, ...rest }: ButtonProps) {
+  const { c, t } = useTheme();
+
+  const byVariant: Record<ButtonVariant, React.CSSProperties> = {
+    default: {
+      padding: `${t.space.md}px ${t.space.lg}px`,
+      fontSize: t.fontSizes.md,
+    },
+    outline: {
+      padding: `${t.space.md}px ${t.space.lg}px`,
+      fontSize: t.fontSizes.md,
+      background: "none",
+      border: `1px solid ${c.border.default}`,
+      color: c.fg.dim,
+    },
+    toolbar: {
+      flex: 1,
+      padding: `${t.space.touch}px ${t.space.lg}px`,
+      fontSize: t.fontSizes.md,
+      background: "transparent",
+      border: `1px solid ${c.border.default}`,
+      color: "inherit",
+    },
+    link: {
+      fontSize: "inherit",
+      background: "none",
+      border: "none",
+      textDecoration: "underline",
+      color: c.fg.dim,
+    },
+  };
+
+  return (
+    <button
+      {...rest}
+      style={{ fontFamily: "inherit", cursor: "pointer", ...byVariant[variant], ...style }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/ui/src/Footer.tsx
+++ b/packages/ui/src/Footer.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "./theme";
+
+export interface FooterProps {
+  children?: React.ReactNode;
+}
+
+/**
+ * The credit line at the bottom of the app. Deliberately the same grey in both themes — it
+ * should recede equally against black and white.
+ */
+export function Footer({ children }: FooterProps) {
+  const { c, t } = useTheme();
+  return (
+    <div
+      style={{
+        padding: t.space.md,
+        textAlign: "center",
+        fontSize: t.fontSizes.sm,
+        color: c.fg.subtle,
+        userSelect: "none",
+        flexShrink: 0,
+      }}
+    >
+      {children ?? (
+        <>
+          notedude &bull; an{" "}
+          <a
+            href="https://nbino.tech"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: c.fg.subtle, textDecoration: "underline" }}
+          >
+            nbino
+          </a>{" "}
+          production
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/HelpOverlay.tsx
+++ b/packages/ui/src/HelpOverlay.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "./theme";
+
+/** A key (or key sequence) and what it does. */
+export type ShortcutRow = [key: string, description: string];
+
+/** A titled group of shortcuts, e.g. `["navigation", [["j / ↓", "next note"], …]]`. */
+export type ShortcutSection = [title: string, rows: ShortcutRow[]];
+
+export interface HelpOverlayProps {
+  sections: ShortcutSection[];
+  onDismiss?: () => void;
+  /** Shown at the bottom in small print. */
+  hint?: string;
+}
+
+/**
+ * The keyboard reference, drawn over the whole app. Its backdrop is near-opaque rather than
+ * a dim scrim: the app behind it is meant to be out of the way, not half-legible.
+ */
+export function HelpOverlay({
+  sections,
+  onDismiss,
+  hint = "press any key or click to close",
+}: HelpOverlayProps) {
+  const { c, t } = useTheme();
+  return (
+    <div
+      data-testid="help-overlay"
+      onClick={onDismiss}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: c.overlay.help,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: t.zIndices.overlay,
+        fontFamily: "inherit",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: t.sizes.overlayMaxWidth,
+          width: "100%",
+          padding: `${t.space.xxl}px ${t.space.xxxl}px`,
+          color: c.fg.default,
+          overflowY: "auto",
+          maxHeight: "90vh",
+        }}
+      >
+        <div style={{ marginBottom: t.space.xl, fontSize: t.fontSizes.lg }}>
+          keyboard shortcuts
+        </div>
+        {sections.map(([section, rows]) => (
+          <div key={section} style={{ marginBottom: 20 }}>
+            <div
+              style={{
+                fontSize: t.fontSizes.xs,
+                opacity: t.opacities.label,
+                textTransform: "uppercase",
+                letterSpacing: t.letterSpacings.label,
+                marginBottom: t.space.md,
+              }}
+            >
+              {section}
+            </div>
+            <table
+              style={{ width: "100%", borderCollapse: "collapse", fontSize: t.fontSizes.md }}
+            >
+              <tbody>
+                {rows.map(([key, desc]) => (
+                  <tr key={key}>
+                    <td
+                      style={{
+                        paddingBottom: t.space.sm,
+                        paddingRight: t.space.xxl,
+                        whiteSpace: "nowrap",
+                        opacity: t.opacities.dim,
+                        width: 100,
+                      }}
+                    >
+                      {key}
+                    </td>
+                    <td style={{ paddingBottom: t.space.sm }}>{desc}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ))}
+        <div
+          style={{ marginTop: t.space.md, fontSize: t.fontSizes.sm, opacity: t.opacities.label }}
+        >
+          {hint}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/MobileToolbar.tsx
+++ b/packages/ui/src/MobileToolbar.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "./theme";
+import { Button } from "./Button";
+
+export interface MobileToolbarProps {
+  /** Which pane the narrow layout is currently showing. */
+  view: "list" | "content";
+  onCompose: () => void;
+  onBack: () => void;
+}
+
+/**
+ * Touch equivalents for the two shortcuts unreachable without a keyboard: `c` to compose,
+ * and Esc to leave the note. Narrow viewports only (#108).
+ */
+export function MobileToolbar({ view, onCompose, onBack }: MobileToolbarProps) {
+  const { c, t } = useTheme();
+  return (
+    <div
+      data-testid="mobile-toolbar"
+      style={{
+        display: "flex",
+        gap: t.space.md,
+        padding: t.space.md,
+        borderTop: `1px solid ${c.border.seam}`,
+      }}
+    >
+      {view === "list" ? (
+        <Button variant="toolbar" data-testid="mobile-compose" onClick={onCompose}>
+          + new note
+        </Button>
+      ) : (
+        <Button variant="toolbar" data-testid="mobile-back" onClick={onBack}>
+          &larr; notes
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/NoteContent.tsx
+++ b/packages/ui/src/NoteContent.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "./theme";
+import { renderWithLinks } from "./noteText";
+
+export interface NoteContentProps {
+  /** The pane's contents: read-only note text, or the editor when editing. */
+  children?: React.ReactNode;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+}
+
+/**
+ * The right pane. It owns the padding that both the read view and the editor sit inside, so
+ * text lands at an identical origin in either mode — the editor resets the browser's default
+ * textarea padding for exactly this reason (#91).
+ */
+export function NoteContent({ children, onClick }: NoteContentProps) {
+  const { t } = useTheme();
+  return (
+    <div
+      data-testid="content-pane"
+      onClick={onClick}
+      style={{
+        flex: 1,
+        padding: t.space.lg,
+        overflowY: "auto",
+        position: "relative",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface NoteTextProps {
+  content: string;
+}
+
+/** Read-only note text: newlines preserved, bare URLs turned into links. */
+export function NoteText({ content }: NoteTextProps) {
+  return (
+    <div style={{ whiteSpace: "pre-wrap", minHeight: "100%" }}>
+      {renderWithLinks(content)}
+    </div>
+  );
+}

--- a/packages/ui/src/NoteEditor.tsx
+++ b/packages/ui/src/NoteEditor.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import React from "react";
+
+export interface NoteEditorProps {
+  value: string;
+  onChange: React.ChangeEventHandler<HTMLTextAreaElement>;
+  onPaste?: React.ClipboardEventHandler<HTMLTextAreaElement>;
+  onSelect?: React.ReactEventHandler<HTMLTextAreaElement>;
+  editorRef?: React.Ref<HTMLTextAreaElement>;
+}
+
+/**
+ * The editing textarea. It inherits face, size, and leading from the content pane and draws
+ * no chrome of its own, so entering and leaving edit mode does not move a single character.
+ *
+ * `padding: 0` is load-bearing: it overrides the browser's default 2px on a textarea, which
+ * otherwise nudged text down and right on edit and back again on save (#91).
+ */
+export function NoteEditor({
+  value,
+  onChange,
+  onPaste,
+  onSelect,
+  editorRef,
+}: NoteEditorProps) {
+  return (
+    <textarea
+      ref={editorRef}
+      role="textbox"
+      value={value}
+      onChange={onChange}
+      onPaste={onPaste}
+      onSelect={onSelect}
+      style={{
+        width: "100%",
+        height: "100%",
+        padding: 0,
+        border: "none",
+        outline: "none",
+        resize: "none",
+        fontFamily: "inherit",
+        fontSize: "inherit",
+        lineHeight: "inherit",
+        background: "transparent",
+        color: "inherit",
+      }}
+    />
+  );
+}

--- a/packages/ui/src/NoteList.tsx
+++ b/packages/ui/src/NoteList.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "./theme";
+import { NoteListItem } from "./NoteListItem";
+import type { NoteSummary } from "./noteText";
+
+export interface NoteListProps {
+  /** Active notes, in display order. */
+  notes: NoteSummary[];
+  /**
+   * Archived notes, shown below the others under an "archived" label. They are not hidden —
+   * they sort to the end (#96) and stay keyboard-navigable (#95).
+   */
+  archivedNotes?: NoteSummary[];
+  selectedId: string;
+  /** Id of the note flashing green after a save, if any. */
+  flashingId?: string | null;
+  onSelect?: (id: string) => void;
+  /** Fill the viewport instead of sitting in a fixed column — narrow layouts (#108). */
+  fullWidth?: boolean;
+  listRef?: React.Ref<HTMLDivElement>;
+}
+
+/** The label separating active notes from archived ones. */
+function ArchivedDivider() {
+  const { t } = useTheme();
+  return (
+    <div
+      data-testid="archived-divider"
+      style={{
+        fontSize: t.fontSizes.xxs,
+        opacity: t.opacities.label,
+        textTransform: "uppercase",
+        letterSpacing: t.letterSpacings.label,
+        padding: `${t.space.sm}px ${t.space.md}px ${t.space.xxs}px`,
+        userSelect: "none",
+      }}
+    >
+      archived
+    </div>
+  );
+}
+
+/** The left pane: every note the current filter admits, active first then archived. */
+export function NoteList({
+  notes,
+  archivedNotes = [],
+  selectedId,
+  flashingId = null,
+  onSelect,
+  fullWidth = false,
+  listRef,
+}: NoteListProps) {
+  const { t } = useTheme();
+
+  const renderItem = (note: NoteSummary, archived: boolean) => (
+    <NoteListItem
+      key={note.id}
+      note={note}
+      archived={archived}
+      selected={note.id === selectedId}
+      flashing={note.id === flashingId}
+      onClick={() => onSelect?.(note.id)}
+    />
+  );
+
+  return (
+    <div
+      ref={listRef}
+      data-testid="list-pane"
+      style={{
+        width: fullWidth ? "100%" : t.sizes.listPaneWidth,
+        overflowY: "auto",
+      }}
+    >
+      {notes.map((note) => renderItem(note, false))}
+      {archivedNotes.length > 0 && <ArchivedDivider />}
+      {archivedNotes.map((note) => renderItem(note, true))}
+    </div>
+  );
+}

--- a/packages/ui/src/NoteListItem.tsx
+++ b/packages/ui/src/NoteListItem.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "./theme";
+import { formatTimestamp, getNoteMetaSnippet, getNoteTitle, type NoteSummary } from "./noteText";
+
+export interface NoteListItemProps {
+  note: NoteSummary;
+  selected: boolean;
+  /** Archived rows stay in the list but recede (#96). */
+  archived: boolean;
+  /** Briefly true right after a save, to flash the row green. */
+  flashing?: boolean;
+  onClick?: () => void;
+}
+
+/**
+ * One row in the list pane: pin indicators and title on top, timestamp and snippet below.
+ * Both lines truncate rather than wrap — the row is a fixed two lines tall so the list
+ * stays scannable.
+ */
+export function NoteListItem({
+  note,
+  selected,
+  archived,
+  flashing = false,
+  onClick,
+}: NoteListItemProps) {
+  const { c, t } = useTheme();
+
+  const background = flashing
+    ? c.bg.saveFlash
+    : selected
+      ? c.bg.selected
+      : "transparent";
+
+  const truncate: React.CSSProperties = {
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  };
+
+  return (
+    <div
+      data-testid="note-item"
+      data-selected={selected ? "true" : "false"}
+      data-pinned={note.pinned ? "true" : "false"}
+      data-tagpinned={note.tagPinned ? "true" : "false"}
+      data-archived={archived ? "true" : "false"}
+      data-flash={flashing ? "true" : "false"}
+      onClick={onClick}
+      style={{
+        padding: t.space.md,
+        cursor: "pointer",
+        background,
+        transition: t.transitions.flash,
+        opacity: archived ? t.opacities.dim : 1,
+      }}
+    >
+      <div
+        data-testid="note-item-title"
+        style={{ fontWeight: 400, fontSize: t.fontSizes.md, ...truncate }}
+      >
+        {note.pinned && <span style={{ marginRight: t.space.xxs }}>○</span>}
+        {note.tagPinned && (
+          <span
+            style={{
+              fontSize: t.fontSizes.bullet,
+              opacity: t.opacities.bullet,
+              marginRight: t.space.xxs,
+            }}
+          >
+            #
+          </span>
+        )}
+        {getNoteTitle(note)}
+      </div>
+      <div
+        data-testid="note-item-meta"
+        style={{ fontSize: t.fontSizes.sm, color: c.fg.muted, ...truncate }}
+      >
+        {formatTimestamp(note.createdAt)} | {getNoteMetaSnippet(note)}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/Rule.tsx
+++ b/packages/ui/src/Rule.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "./theme";
+
+/**
+ * The app draws its rules as repeated characters rather than borders, so they sit on the
+ * same character grid as everything else and read as part of the monospace surface.
+ */
+
+export interface RuleProps {
+  /** How many `- ` pairs to lay down. The row clips, so this only needs to over-fill. */
+  repeat?: number;
+}
+
+/** The horizontal `- - - -` rule under the search bar. */
+export function Rule({ repeat = 300 }: RuleProps) {
+  const { c, t } = useTheme();
+  return (
+    <div
+      style={{
+        overflow: "hidden",
+        whiteSpace: "nowrap",
+        color: c.fg.rule,
+        lineHeight: String(t.lineHeights.normal),
+        userSelect: "none",
+        flexShrink: 0,
+        fontSize: t.fontSizes.md,
+      }}
+    >
+      {"- ".repeat(repeat)}
+    </div>
+  );
+}
+
+export interface PaneDividerProps {
+  /**
+   * How many `|` rows to draw. The caller measures the taller of the two panes and passes
+   * enough rows to cover it — a short divider leaves a visible gap down the page.
+   */
+  rows: number;
+}
+
+/** The vertical `|` column between the list and content panes. Exactly one character wide. */
+export function PaneDivider({ rows }: PaneDividerProps) {
+  const { c, t } = useTheme();
+  return (
+    <div
+      data-testid="divider"
+      style={{
+        overflow: "hidden",
+        whiteSpace: "pre",
+        color: c.fg.rule,
+        lineHeight: String(t.lineHeights.normal),
+        userSelect: "none",
+        width: t.sizes.dividerWidth,
+        fontSize: t.fontSizes.md,
+      }}
+    >
+      {"|\n".repeat(rows)}
+    </div>
+  );
+}

--- a/packages/ui/src/SearchBar.tsx
+++ b/packages/ui/src/SearchBar.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "./theme";
+
+export interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  /**
+   * False puts the input in `readOnly` — the app is not in its search state, so the box
+   * shows the active filter but does not accept typing until it is clicked.
+   */
+  active: boolean;
+  /** Called when a non-active bar is clicked, to enter the search state. */
+  onActivate?: () => void;
+  placeholder?: string;
+  inputRef?: React.Ref<HTMLInputElement>;
+}
+
+/**
+ * The prompt row at the top of the app: a `>` sigil and a borderless input that reads as
+ * part of the page rather than as a form control.
+ */
+export function SearchBar({
+  value,
+  onChange,
+  active,
+  onActivate,
+  placeholder = "search notes...",
+  inputRef,
+}: SearchBarProps) {
+  const { t } = useTheme();
+  return (
+    <div
+      data-testid="top-pane"
+      style={{
+        padding: `${t.space.md}px`,
+        display: "flex",
+        alignItems: "center",
+        flexShrink: 0,
+      }}
+    >
+      <span style={{ userSelect: "none", marginRight: t.space.xs }}>&gt;</span>
+      <input
+        ref={inputRef}
+        type="search"
+        role="searchbox"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        readOnly={!active}
+        onClick={() => { if (!active) onActivate?.(); }}
+        style={{
+          width: "100%",
+          padding: `${t.space.xs}px 0`,
+          fontFamily: "inherit",
+          fontSize: "inherit",
+          border: "none",
+          outline: "none",
+          background: "transparent",
+          color: "inherit",
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/TagDropdown.tsx
+++ b/packages/ui/src/TagDropdown.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "./theme";
+
+export interface TagSuggestion {
+  tag: string;
+  lastUsed: number;
+}
+
+/**
+ * `search` hangs full-width beneath the search bar; `editor` is a popover pinned to the
+ * caret inside the note editor. They are the same list with different anchoring, so they
+ * are the same component — the variant decides placement, test ids, and how a row is
+ * committed.
+ */
+export type TagDropdownVariant = "search" | "editor";
+
+export interface TagDropdownProps {
+  variant: TagDropdownVariant;
+  tags: TagSuggestion[];
+  /** Index of the keyboard-highlighted row, or -1 for none. */
+  selectedIndex: number;
+  onSelect: (tag: string) => void;
+  /**
+   * How many leading entries are "recently used". A rule is drawn after them to separate
+   * recency-ordered suggestions from the alphabetical remainder.
+   */
+  recentCount: number;
+  /** Caret position for the `editor` variant. Ignored by `search`. */
+  position?: { top: number; left: number };
+}
+
+export function TagDropdown({
+  variant,
+  tags,
+  selectedIndex,
+  onSelect,
+  recentCount,
+  position,
+}: TagDropdownProps) {
+  const { c, t } = useTheme();
+  if (tags.length === 0) return null;
+
+  const isEditor = variant === "editor";
+  const prefix = isEditor ? "editor-tag" : "tag";
+
+  const container: React.CSSProperties = isEditor
+    ? {
+        position: "absolute",
+        top: position?.top ?? 0,
+        left: position?.left ?? 0,
+        background: c.bg.raised,
+        border: `1px solid ${c.border.subtle}`,
+        zIndex: t.zIndices.popover,
+        minWidth: t.sizes.tagPopoverMinWidth,
+      }
+    : {
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        padding: `${t.space.xs}px ${t.space.md}px`,
+        background: c.bg.raised,
+        border: `1px solid ${c.border.subtle}`,
+      };
+
+  // The search list only rules off a recent section that actually has entries; the editor
+  // list cannot reach `recentCount === 0` with rows present, so the extra guard is omitted.
+  const showSeparatorAt = (i: number) =>
+    i === recentCount && recentCount < tags.length && (isEditor || recentCount > 0);
+
+  return (
+    <div data-testid={`${prefix}-dropdown`} style={container}>
+      {tags.map(({ tag }, i) => (
+        <div key={tag}>
+          {showSeparatorAt(i) && (
+            <div
+              data-testid={`${prefix}-separator`}
+              style={{
+                borderTop: `1px solid ${c.border.default}`,
+                margin: `${t.space.xs}px 0`,
+              }}
+            />
+          )}
+          <div
+            data-testid={`${prefix}-item`}
+            data-selected={i === selectedIndex ? "true" : "false"}
+            // The editor list commits on mousedown with the default prevented, so the
+            // textarea never loses focus and the caret stays where the tag is going.
+            {...(isEditor
+              ? { onMouseDown: (e: React.MouseEvent) => { e.preventDefault(); onSelect(tag); } }
+              : { onClick: () => onSelect(tag) })}
+            style={{
+              padding: `${t.space.xs}px ${t.space.md}px`,
+              cursor: "pointer",
+              background: i === selectedIndex ? c.bg.selected : "transparent",
+            }}
+          >
+            {tag}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/TaskMoveDialog.tsx
+++ b/packages/ui/src/TaskMoveDialog.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "./theme";
+
+export interface TaskMoveDialogProps {
+  /** The task lists to choose from, in the order they should appear. */
+  tags: string[];
+  /** Index of the keyboard-highlighted row. */
+  selectedIndex: number;
+  onSelect: (tag: string) => void;
+  onDismiss?: () => void;
+  label?: string;
+}
+
+/**
+ * The `t → m` chooser. Unlike the help overlay this is a true modal over a dim scrim: the
+ * note it acts on stays visible behind it.
+ */
+export function TaskMoveDialog({
+  tags,
+  selectedIndex,
+  onSelect,
+  onDismiss,
+  label = "move note to task list",
+}: TaskMoveDialogProps) {
+  const { c, t } = useTheme();
+  return (
+    <div
+      data-testid="task-move-overlay"
+      onClick={onDismiss}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: c.overlay.scrim,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: t.zIndices.dialog,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: c.bg.dialog,
+          border: `1px solid ${c.border.strong}`,
+          borderRadius: t.radii.md,
+          padding: `${t.space.lg}px ${t.space.xl}px`,
+          minWidth: t.sizes.dialogMinWidth,
+          fontFamily: t.fonts.mono,
+          fontSize: t.fontSizes.md,
+        }}
+      >
+        <div
+          style={{
+            marginBottom: t.space.touch,
+            fontSize: t.fontSizes.sm,
+            opacity: t.opacities.dim,
+          }}
+        >
+          {label}
+        </div>
+        {tags.map((tag, i) => (
+          <div
+            key={tag}
+            data-testid="task-move-item"
+            data-selected={i === selectedIndex ? "true" : "false"}
+            onClick={() => onSelect(tag)}
+            style={{
+              padding: `${t.space.sm}px ${t.space.md}px`,
+              borderRadius: t.radii.sm,
+              cursor: "pointer",
+              background: i === selectedIndex ? c.bg.selectedMuted : "transparent",
+              color: c.fg.default,
+            }}
+          >
+            {tag}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,78 @@
+/**
+ * @notedude/ui — the notedude design system.
+ *
+ * Wrap any tree in `<ThemeProvider theme="dark">` before using these; components read
+ * colours from it and throw without one.
+ */
+
+export {
+  tokens,
+  colors,
+  fonts,
+  fontSizes,
+  lineHeights,
+  space,
+  radii,
+  opacities,
+  sizes,
+  zIndices,
+  letterSpacings,
+  transitions,
+  type Tokens,
+  type ThemedColor,
+} from "./tokens";
+
+export {
+  ThemeProvider,
+  useTheme,
+  type Theme,
+  type ThemeName,
+  type ThemeProviderProps,
+  type ResolvedColors,
+} from "./theme";
+
+export { Button, type ButtonProps, type ButtonVariant } from "./Button";
+export { Rule, PaneDivider, type RuleProps, type PaneDividerProps } from "./Rule";
+export { SearchBar, type SearchBarProps } from "./SearchBar";
+export {
+  TagDropdown,
+  type TagDropdownProps,
+  type TagDropdownVariant,
+  type TagSuggestion,
+} from "./TagDropdown";
+export { NoteList, type NoteListProps } from "./NoteList";
+export { NoteListItem, type NoteListItemProps } from "./NoteListItem";
+export { NoteContent, NoteText, type NoteContentProps, type NoteTextProps } from "./NoteContent";
+export { NoteEditor, type NoteEditorProps } from "./NoteEditor";
+export {
+  HelpOverlay,
+  type HelpOverlayProps,
+  type ShortcutRow,
+  type ShortcutSection,
+} from "./HelpOverlay";
+export { TaskMoveDialog, type TaskMoveDialogProps } from "./TaskMoveDialog";
+export {
+  AppShell,
+  AppSlot,
+  AccountHeader,
+  type AppShellProps,
+  type AppSlotProps,
+  type AccountHeaderProps,
+} from "./AppShell";
+export { Footer, type FooterProps } from "./Footer";
+export { MobileToolbar, type MobileToolbarProps } from "./MobileToolbar";
+export {
+  LoginScreen,
+  LoadingScreen,
+  type LoginScreenProps,
+  type LoadingScreenProps,
+} from "./screens";
+
+export {
+  getNoteTitle,
+  getNoteMetaSnippet,
+  formatTimestamp,
+  renderWithLinks,
+  contentWithoutTags,
+  type NoteSummary,
+} from "./noteText";

--- a/packages/ui/src/noteText.tsx
+++ b/packages/ui/src/noteText.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { colors } from "./tokens";
+
+/**
+ * The shape the list and content components need in order to render a note. The app's own
+ * `Note` satisfies this structurally; the library deliberately knows nothing about pinning
+ * persistence, sync state, or archiving rules beyond what it draws.
+ */
+export interface NoteSummary {
+  id: string;
+  content: string;
+  pinned: boolean;
+  tagPinned: boolean;
+  createdAt: number;
+  /** True until the user first edits content — an untouched new note titles as "New Note". */
+  isNew?: boolean;
+}
+
+/** What is left of a note once every #tag is stripped out. */
+export function contentWithoutTags(content: string): string {
+  return content.replace(/#[\w-]+/g, "").trim();
+}
+
+/**
+ * Index of the first line with something on it, or -1 if every line is blank. The title is
+ * this line, not literally line 1: a note that opens with empty lines still has a title, it
+ * just sits further down (#126).
+ */
+function firstNonBlankIndex(lines: string[]): number {
+  return lines.findIndex((l) => l.trim() !== "");
+}
+
+export function getNoteTitle(note: Pick<NoteSummary, "content" | "isNew">): string {
+  if (note.isNew && contentWithoutTags(note.content) === "") return "New Note";
+  const lines = note.content.split("\n");
+  const titleIdx = firstNonBlankIndex(lines);
+  // Reserved for notes that genuinely hold no text — whitespace-only included.
+  return titleIdx === -1 ? "No Text Entered" : lines[titleIdx];
+}
+
+export function getNoteMetaSnippet(note: Pick<NoteSummary, "content">): string {
+  if (contentWithoutTags(note.content) === "") return "No Content";
+  const lines = note.content.split("\n");
+  const titleIdx = firstNonBlankIndex(lines);
+  if (titleIdx === -1) return "No Content";
+  // Search below the title line, wherever that turned out to be.
+  const snippet = lines.slice(titleIdx + 1).find((l) => l.trim() !== "") ?? "";
+  return snippet.length > 30 ? snippet.slice(0, 30) + "…" : snippet;
+}
+
+/** Time today, weekday this week, month+day beyond that. */
+export function formatTimestamp(ts: number): string {
+  const d = new Date(ts);
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfWeek = new Date(startOfToday);
+  startOfWeek.setDate(startOfToday.getDate() - startOfToday.getDay());
+
+  if (d >= startOfToday) {
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+  if (d >= startOfWeek) {
+    return d.toLocaleDateString([], { weekday: "short" });
+  }
+  return d.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+const URL_RE = /https?:\/\/[^\s<>"]+/g;
+
+/** Splits text into nodes, turning bare URLs into new-tab links that inherit their colour. */
+export function renderWithLinks(text: string): React.ReactNode[] {
+  const parts: React.ReactNode[] = [];
+  let last = 0;
+  for (const m of text.matchAll(URL_RE)) {
+    if (m.index! > last) parts.push(text.slice(last, m.index));
+    parts.push(
+      <a
+        key={m.index}
+        href={m[0]}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ color: "inherit", textDecorationColor: colors.fg.subtle.dark }}
+      >
+        {m[0]}
+      </a>
+    );
+    last = m.index! + m[0].length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts;
+}

--- a/packages/ui/src/screens.tsx
+++ b/packages/ui/src/screens.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import React from "react";
+import { useTheme } from "./theme";
+import { Button } from "./Button";
+
+/** Shared centring for the two full-viewport pre-app screens. */
+function centered(extra?: React.CSSProperties): React.CSSProperties {
+  return {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    height: "100vh",
+    ...extra,
+  };
+}
+
+export interface LoadingScreenProps {
+  label?: string;
+}
+
+/** Shown while auth resolves, before we know which screen is next. */
+export function LoadingScreen({ label = "loading..." }: LoadingScreenProps) {
+  const { c, t } = useTheme();
+  return (
+    <div
+      style={centered({
+        fontFamily: t.fonts.mono,
+        background: c.bg.app,
+        color: c.fg.default,
+      })}
+    >
+      {label}
+    </div>
+  );
+}
+
+export interface LoginScreenProps {
+  onSignIn: () => void;
+  onDemo: () => void;
+  /** A failed sign-in used to look identical to no sign-in at all (#132). */
+  error?: string | null;
+  title?: string;
+}
+
+/** The signed-out screen: brand, the two ways in, and any sign-in failure. */
+export function LoginScreen({ onSignIn, onDemo, error, title = "notedude" }: LoginScreenProps) {
+  const { c, t } = useTheme();
+  return (
+    <div
+      data-testid="login-screen"
+      style={centered({
+        flexDirection: "column",
+        fontFamily: t.fonts.mono,
+        gap: t.space.lg,
+        background: c.bg.app,
+        color: c.fg.default,
+      })}
+    >
+      <div>{title}</div>
+      <Button onClick={onSignIn}>⏎ sign in with google</Button>
+      <Button variant="outline" onClick={onDemo}>
+        <u>d</u>emo mode
+      </Button>
+      {error && (
+        <div
+          data-testid="login-error"
+          role="alert"
+          style={{
+            fontSize: t.fontSizes.sm,
+            maxWidth: 380,
+            textAlign: "center",
+            color: c.fg.danger,
+          }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/theme.tsx
+++ b/packages/ui/src/theme.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import React, { createContext, useContext, useMemo } from "react";
+import { colors, type ThemedColor, tokens } from "./tokens";
+
+export type ThemeName = "dark" | "light";
+
+/**
+ * `colors` with every dark/light pair collapsed to the string for the active theme, so a
+ * component writes `c.bg.app` instead of re-deciding `darkMode ? ... : ...` at each use.
+ */
+export type ResolvedColors = {
+  [Group in keyof typeof colors]: {
+    [Name in keyof (typeof colors)[Group]]: string;
+  };
+};
+
+function resolve(theme: ThemeName): ResolvedColors {
+  const out = {} as Record<string, Record<string, string>>;
+  for (const [group, entries] of Object.entries(colors)) {
+    out[group] = Object.fromEntries(
+      Object.entries(entries as Record<string, ThemedColor>).map(([name, value]) => [
+        name,
+        value[theme],
+      ])
+    );
+  }
+  return out as ResolvedColors;
+}
+
+export interface Theme {
+  name: ThemeName;
+  /** True when `name === "dark"`. Kept for the few places that genuinely branch on it. */
+  isDark: boolean;
+  /** Theme-resolved colours. */
+  c: ResolvedColors;
+  /** Everything theme-independent: type scale, spacing, radii, z-indices. */
+  t: typeof tokens;
+}
+
+const ThemeContext = createContext<Theme | null>(null);
+
+export interface ThemeProviderProps {
+  theme: ThemeName;
+  children: React.ReactNode;
+}
+
+/**
+ * Supplies the active theme to every component below it.
+ *
+ * Components are unstyled without it — `useTheme` throws rather than silently falling back
+ * to dark, because a wrong-but-plausible theme is far harder to notice than a crash.
+ */
+export function ThemeProvider({ theme, children }: ThemeProviderProps) {
+  const value = useMemo<Theme>(
+    () => ({ name: theme, isDark: theme === "dark", c: resolve(theme), t: tokens }),
+    [theme]
+  );
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): Theme {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error("useTheme must be used inside a <ThemeProvider>. Wrap your tree in one.");
+  }
+  return ctx;
+}

--- a/packages/ui/src/tokens.ts
+++ b/packages/ui/src/tokens.ts
@@ -1,0 +1,176 @@
+/**
+ * The notedude design tokens.
+ *
+ * Every value here was previously an inline literal in `App.tsx` or `page.tsx` — in several
+ * cases the same literal derived independently in both files. Tokens are the single place a
+ * colour, step, or size is decided; components read them and never hard-code.
+ *
+ * Colours come in dark/light pairs because the app ships both themes. `ThemeProvider`
+ * resolves a pair to the active side, so a component asks for `c.bg.app`, never for
+ * `darkMode ? "#1a1a1a" : "#ffffff"`.
+ */
+
+/** A colour that differs between the two themes. */
+export interface ThemedColor {
+  dark: string;
+  light: string;
+}
+
+const pair = (dark: string, light: string): ThemedColor => ({ dark, light });
+
+export const colors = {
+  bg: {
+    /** The app canvas. */
+    app: pair("#1a1a1a", "#ffffff"),
+    /** Dropdowns and the task-move dialog — one step up from the canvas. */
+    raised: pair("#2a2a2a", "#f5f5f5"),
+    /** The task-move dialog specifically: pure white in light mode, not the dropdown grey. */
+    dialog: pair("#2a2a2a", "#ffffff"),
+    /** The selected note, and the highlighted row in either tag dropdown. */
+    selected: pair("#3a3a6a", "#e0e7ff"),
+    /** The highlighted row inside the task-move dialog. */
+    selectedMuted: pair("#444444", "#e8e8e8"),
+    /** The green pulse confirming a note was saved. */
+    saveFlash: pair("#1a7a1a", "#6fcf7f"),
+    transparent: pair("transparent", "transparent"),
+  },
+  fg: {
+    /** Body text. */
+    default: pair("#e8e8e8", "#000000"),
+    /** Note metadata — the timestamp and snippet line. */
+    muted: pair("#999999", "#666666"),
+    /** The account header and the secondary buttons on the pre-app screens. */
+    dim: pair("#888888", "#666666"),
+    /** The footer, and the underline under a link in note content — grey in both themes. */
+    subtle: pair("#888888", "#888888"),
+    /** The `- -` and `|` rules drawn as text. */
+    rule: pair("#555555", "#000000"),
+    /** Sign-in failure. */
+    danger: pair("#ff8a8a", "#b00020"),
+  },
+  border: {
+    /** Dropdown outlines and button outlines. */
+    default: pair("#444444", "#cccccc"),
+    /** Dropdown container edges, slightly lighter in light mode. */
+    subtle: pair("#444444", "#dddddd"),
+    /** The task-move dialog edge. */
+    strong: pair("#555555", "#cccccc"),
+    /** Above the mobile toolbar — darker than `default` so it reads as a seam, not an edge. */
+    seam: pair("#333333", "#dddddd"),
+  },
+  overlay: {
+    /** Behind the help overlay: near-opaque, so the app is hidden rather than dimmed. */
+    help: pair("rgba(0,0,0,0.85)", "rgba(255,255,255,0.95)"),
+    /** Behind the task-move dialog: a true scrim, identical in both themes. */
+    scrim: pair("rgba(0,0,0,0.5)", "rgba(0,0,0,0.5)"),
+  },
+} as const;
+
+/**
+ * The app is monospace end to end — the layout leans on character cells (the `|` divider is
+ * exactly `1ch` wide), so this is structural, not decorative.
+ */
+export const fonts = {
+  mono: "'Fira Code', monospace",
+} as const;
+
+export const fontSizes = {
+  /** Overlay titles. */
+  lg: 16,
+  /** Body, note titles, list rows. */
+  md: 14,
+  /** Note metadata, the footer, dialog labels. */
+  sm: 12,
+  /** Section headings inside the help overlay. */
+  xs: 11,
+  /** The "archived" divider label. */
+  xxs: 10,
+  /** The `#` tag-pin bullet, sized relative to the title it sits in. */
+  bullet: "0.75em",
+} as const;
+
+/** Matches the `1.4` used for the rules, so their rows line up with note text. */
+export const lineHeights = {
+  normal: 1.4,
+} as const;
+
+export const space = {
+  none: 0,
+  xxs: 2,
+  xs: 4,
+  sm: 6,
+  md: 8,
+  /** Vertical padding on touch targets — the mobile toolbar buttons, dialog labels. */
+  touch: 12,
+  lg: 16,
+  xl: 24,
+  xxl: 32,
+  xxxl: 40,
+} as const;
+
+export const radii = {
+  none: 0,
+  sm: 4,
+  md: 6,
+} as const;
+
+export const opacities = {
+  /** Section labels and the "archived" divider. */
+  label: 0.4,
+  /** Archived rows in the list, and help-overlay key cells. */
+  dim: 0.5,
+  /** The `#` tag-pin bullet. */
+  bullet: 0.6,
+} as const;
+
+export const sizes = {
+  /** The list pane on a desktop viewport. */
+  listPaneWidth: 250,
+  /** One character cell — the vertical `|` rule is exactly this wide. */
+  dividerWidth: "1ch",
+  /** The help overlay's readable column. */
+  overlayMaxWidth: 560,
+  /** The task-move dialog. */
+  dialogMinWidth: 220,
+  /** The editor's tag-completion popup. */
+  tagPopoverMinWidth: 120,
+  /** Below this the two panes cannot sit side by side and stay usable (#108). */
+  narrowBreakpoint: 640,
+} as const;
+
+export const zIndices = {
+  /** The editor's tag popup, above note text. */
+  popover: 10,
+  /** The search tag dropdown, above both panes. */
+  dropdown: 20,
+  /** The help overlay. */
+  overlay: 100,
+  /** The task-move dialog, above the help overlay. */
+  dialog: 200,
+} as const;
+
+/** Letter-spacing for the small uppercase labels. */
+export const letterSpacings = {
+  label: "0.08em",
+} as const;
+
+/** How long the save-confirmation background takes to fade back out. */
+export const transitions = {
+  flash: "background 0.3s ease",
+} as const;
+
+export const tokens = {
+  colors,
+  fonts,
+  fontSizes,
+  lineHeights,
+  space,
+  radii,
+  opacities,
+  sizes,
+  zIndices,
+  letterSpacings,
+  transitions,
+} as const;
+
+export type Tokens = typeof tokens;

--- a/packages/ui/tsconfig.build.json
+++ b/packages/ui/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/spec.md
+++ b/spec.md
@@ -267,6 +267,51 @@ Note *creation* and the discard of an untouched note are also excluded: creation
 - Dark mode uses a dark background, light text, and adjusted borders and highlights
 - The default dark background is applied globally (via the root layout, before first paint) so the page loads dark with no light flash; the login screen and pre-app screens (loading, demo-mode bar, signed-in bar) follow the same default and respect an explicit light preference
 
+### Two independent theme readers
+
+The pre-app chrome (`src/app/page.tsx`) and the app itself (`App.tsx`) each read the stored preference on mount and hold their own copy. Only the app's copy is toggled by `d → m`, so **toggling the theme repaints the app but not the surrounding chrome until the next load**. This is long-standing behaviour and is preserved deliberately; changing it is a behavioural change, not a refactor.
+
+## Design System (`@notedude/ui`)
+
+The presentational layer lives in a workspace package at `packages/ui`, built to `dist/` (esbuild for the bundle, `tsc` for declarations) with React left external so the app and the library share one instance. The app's `prebuild` / `predev` scripts build it.
+
+**The split:** the library draws, the app decides. `App.tsx` keeps the state machine, the global keyboard handler, Firestore sync, undo/redo, and all filtering and sorting. The library holds no application state and never reaches the network.
+
+### Tokens
+
+`tokens.ts` is the single place a colour, step, or size is decided. Colours are declared as dark/light pairs; `ThemeProvider` resolves a pair to the active side so a component reads `c.bg.app` rather than re-deciding the theme at each use.
+
+| Group | Covers |
+|---|---|
+| `colors` | canvas, raised surfaces, selection, save-flash, text (default / muted / dim / subtle / danger), borders, overlays |
+| `fonts`, `fontSizes`, `lineHeights` | `'Fira Code', monospace`; the 16 / 14 / 12 / 11 / 10 scale |
+| `space`, `radii` | 0 / 2 / 4 / 6 / 8 / 12 / 16 / 24 / 32 / 40; radii 4 and 6 |
+| `sizes`, `zIndices` | list-pane width, `1ch` divider, breakpoint; popover → dropdown → overlay → dialog |
+| `opacities`, `letterSpacings`, `transitions` | label / dim / bullet; the uppercase label tracking; the save-flash fade |
+
+Three greys are deliberately distinct and must not be collapsed: `fg.muted` (note metadata), `fg.dim` (account header and secondary buttons), and `fg.subtle` (the footer — the same grey in *both* themes, so it recedes equally against black and white).
+
+### Components
+
+| Area | Components |
+|---|---|
+| Foundation | `ThemeProvider` / `useTheme`, `Button` |
+| Layout & chrome | `AppShell`, `AppSlot`, `AccountHeader`, `SearchBar`, `Rule`, `PaneDivider`, `MobileToolbar`, `Footer` |
+| Notes | `NoteList`, `NoteListItem`, `NoteContent`, `NoteText`, `NoteEditor`, `TagDropdown` |
+| Screens & overlays | `HelpOverlay`, `TaskMoveDialog`, `LoginScreen`, `LoadingScreen` |
+
+Notes on specific components:
+
+- **`TagDropdown`** serves both the search dropdown and the editor's caret popover. They are one component with a `variant`, differing only in anchoring, test-id prefix, and how a row commits — the editor variant commits on `mousedown` with the default prevented, so the textarea never loses focus and the caret stays where the tag is going.
+- **`useTheme` throws** when used outside a `ThemeProvider` rather than defaulting to dark. A wrong-but-plausible theme is far harder to notice than a crash.
+- **`NoteEditor`** sets `padding: 0` to override the browser's 2px textarea default, which is what keeps text from shifting between read and edit modes (#91).
+
+### Gallery
+
+`/test/ui` renders every component with representative props, and `e2e/ui-gallery.spec.ts` drives its contract tests through that route: rendering, the test ids the app suite depends on, per-theme colour resolution, and the monospace character grid the layout is built on. `?theme=light` switches the gallery's theme.
+
+The gallery is also the set of worked usage examples the design-system export is generated from.
+
 ## Note List Item Display (Apple Notes Style)
 
 Each note in the List Pane displays two lines:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,16 @@
 import App from "@/components/App";
 import { useAuth } from "@/lib/useAuth";
 import { useEffect, useState } from "react";
+import {
+  AccountHeader,
+  AppShell,
+  AppSlot,
+  Button,
+  LoadingScreen,
+  LoginScreen,
+  ThemeProvider,
+  space,
+} from "@notedude/ui";
 
 // Local-dev convenience only — auth can never be bypassed in a production build,
 // even if NEXT_PUBLIC_SKIP_AUTH leaks into the deployed environment.
@@ -10,7 +20,11 @@ const SKIP_AUTH =
   process.env.NEXT_PUBLIC_SKIP_AUTH === "true" && process.env.NODE_ENV !== "production";
 
 // Dark mode is the default for the pre-app screens too; only switch to light if
-// the user has explicitly chosen it (mirrors the logic in App.tsx).
+// the user has explicitly chosen it.
+//
+// This is read once on mount and is deliberately independent of the theme App keeps for
+// itself: toggling dark mode with `d → m` inside the app repaints the app, not this
+// chrome, until the next load. That has always been the behaviour.
 function useDarkMode(): boolean {
   const [darkMode, setDarkMode] = useState(true);
   useEffect(() => {
@@ -34,82 +48,61 @@ export default function Page() {
     return () => window.removeEventListener("keydown", handleKey);
   }, [loading, user, demoMode, login]);
 
-  const bg = darkMode ? "#1a1a1a" : "#ffffff";
-  const fg = darkMode ? "#e8e8e8" : "#000000";
-  const muted = darkMode ? "#888" : "#666";
-  const border = darkMode ? "#444" : "#ccc";
+  const theme = darkMode ? "dark" : "light";
 
-  // A flex item's default `min-height: auto` resolves to its *content's* height, so a bare
-  // `flex: 1` wrapper refuses to shrink below the app's content and pushes the page taller
-  // than the viewport — which is what scrolled the header off screen in #124. `minHeight: 0`
-  // lets it shrink to the space actually available; `overflow: hidden` on the shell makes
-  // sure nothing can scroll the page even if something else grows unexpectedly.
-  const shell = { height: "100vh", display: "flex", flexDirection: "column" as const, background: bg, overflow: "hidden" };
-  const appSlot = { flex: 1, minHeight: 0 };
-  // Never compressed, never scrolled away.
-  const headerRow = {
-    display: "flex", justifyContent: "flex-end", padding: "4px 8px", fontSize: 12,
-    fontFamily: "'Fira Code', monospace", color: muted, flexShrink: 0,
+  const body = () => {
+    if (SKIP_AUTH) {
+      return (
+        <AppShell>
+          <AppSlot>
+            <App />
+          </AppSlot>
+        </AppShell>
+      );
+    }
+
+    if (loading) return <LoadingScreen />;
+
+    if (demoMode) {
+      return (
+        <AppShell>
+          <AccountHeader>
+            demo mode —{" "}
+            <Button
+              variant="link"
+              style={{ marginLeft: space.sm }}
+              onClick={() => setDemoMode(false)}
+            >
+              sign in
+            </Button>
+          </AccountHeader>
+          <AppSlot>
+            <App demo onLogout={() => setDemoMode(false)} />
+          </AppSlot>
+        </AppShell>
+      );
+    }
+
+    if (!user) {
+      return (
+        <LoginScreen onSignIn={login} onDemo={() => setDemoMode(true)} error={error} />
+      );
+    }
+
+    return (
+      <AppShell>
+        <AccountHeader>
+          {user.email}{" "}
+          <Button variant="link" style={{ marginLeft: space.md }} onClick={logout}>
+            logout
+          </Button>
+        </AccountHeader>
+        <AppSlot>
+          <App uid={user.uid} onLogout={logout} />
+        </AppSlot>
+      </AppShell>
+    );
   };
 
-  if (SKIP_AUTH) {
-    return (
-      <div style={shell}>
-        <div style={appSlot}>
-          <App />
-        </div>
-      </div>
-    );
-  }
-
-  if (loading) {
-    return <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", fontFamily: "'Fira Code', monospace", background: bg, color: fg }}>loading...</div>;
-  }
-
-  if (demoMode) {
-    return (
-      <div style={shell}>
-        <div data-testid="account-header" style={headerRow}>
-          demo mode —{" "}
-          <button onClick={() => setDemoMode(false)} style={{ marginLeft: 6, fontFamily: "inherit", fontSize: "inherit", cursor: "pointer", background: "none", border: "none", textDecoration: "underline", color: muted }}>
-            sign in
-          </button>
-        </div>
-        <div style={appSlot}>
-          <App demo onLogout={() => setDemoMode(false)} />
-        </div>
-      </div>
-    );
-  }
-
-  if (!user) {
-    return (
-      <div data-testid="login-screen" style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", height: "100vh", fontFamily: "'Fira Code', monospace", gap: 16, background: bg, color: fg }}>
-        <div>notedude</div>
-        <button onClick={login} style={{ padding: "8px 16px", fontFamily: "inherit", fontSize: 14, cursor: "pointer" }}>
-          ⏎ sign in with google
-        </button>
-        <button onClick={() => setDemoMode(true)} style={{ padding: "8px 16px", fontFamily: "inherit", fontSize: 14, cursor: "pointer", background: "none", border: `1px solid ${border}`, color: muted }}>
-          <u>d</u>emo mode
-        </button>
-        {/* A failed sign-in used to look identical to no sign-in at all (#132). */}
-        {error && (
-          <div data-testid="login-error" role="alert" style={{ fontSize: 12, maxWidth: 380, textAlign: "center", color: darkMode ? "#ff8a8a" : "#b00020" }}>
-            {error}
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  return (
-    <div style={shell}>
-      <div data-testid="account-header" style={headerRow}>
-        {user.email} <button onClick={logout} style={{ marginLeft: 8, fontFamily: "inherit", fontSize: "inherit", cursor: "pointer", background: "none", border: "none", textDecoration: "underline", color: muted }}>logout</button>
-      </div>
-      <div style={appSlot}>
-        <App uid={user.uid} onLogout={logout} />
-      </div>
-    </div>
-  );
+  return <ThemeProvider theme={theme}>{body()}</ThemeProvider>;
 }

--- a/src/app/test/ui/page.tsx
+++ b/src/app/test/ui/page.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+/**
+ * Component gallery for @notedude/ui.
+ *
+ * Every component in the library is rendered here with representative props. It exists for
+ * two reasons: `e2e/ui-gallery.spec.ts` drives its contract tests through this page, and it
+ * is the set of worked usage examples the design-system export is generated from.
+ *
+ * Nothing here reaches Firestore or the auth layer — the library is presentational, so the
+ * gallery hands it plain data and records what it calls back with.
+ */
+
+import React, { useEffect, useState } from "react";
+import {
+  AccountHeader,
+  Button,
+  Footer,
+  HelpOverlay,
+  LoadingScreen,
+  LoginScreen,
+  MobileToolbar,
+  NoteContent,
+  NoteEditor,
+  NoteList,
+  NoteText,
+  PaneDivider,
+  Rule,
+  SearchBar,
+  TagDropdown,
+  TaskMoveDialog,
+  ThemeProvider,
+  tokens,
+  type NoteSummary,
+  type ShortcutSection,
+  type ThemeName,
+} from "@notedude/ui";
+
+// Fixed and well in the past, so the rendered timestamps never depend on the run date.
+const T = Date.UTC(2020, 2, 15, 12, 0, 0);
+
+const NOTES: NoteSummary[] = [
+  { id: "n1", content: "Welcome to notedude #intro\nYour keyboard-driven note app.", pinned: true, tagPinned: false, createdAt: T },
+  { id: "n2", content: "Getting started #guide\nPress 'c' to create a new note.", pinned: false, tagPinned: true, createdAt: T },
+  { id: "n3", content: "\n\nburied title\nand its body", pinned: false, tagPinned: false, createdAt: T },
+  { id: "n4", content: " #project", pinned: false, tagPinned: false, createdAt: T, isNew: true },
+];
+
+const ARCHIVED: NoteSummary[] = [
+  { id: "n5", content: "Old thoughts #archived\nkept, but out of the way", pinned: false, tagPinned: false, createdAt: T },
+];
+
+const TAGS = [
+  { tag: "#intro", lastUsed: T },
+  { tag: "#guide", lastUsed: T },
+  { tag: "#project", lastUsed: T },
+];
+
+const SHORTCUTS: ShortcutSection[] = [
+  ["navigation", [["j / ↓", "next note"], ["k / ↑", "previous note"]]],
+  ["etc", [["?", "show this"]]],
+];
+
+const TASK_TAGS = ["#tasks-inbox", "#tasks-today", "#tasks-done"];
+
+const NOTE_BODY =
+  "A note with a link: https://example.com/notes\nand a second line below it.";
+
+function Section({ name, title, children }: { name: string; title: string; children: React.ReactNode }) {
+  return (
+    <section
+      data-testid={`gallery-${name}`}
+      style={{ marginBottom: tokens.space.xxl, position: "relative" }}
+    >
+      <h2
+        style={{
+          fontSize: tokens.fontSizes.xs,
+          opacity: tokens.opacities.label,
+          textTransform: "uppercase",
+          letterSpacing: tokens.letterSpacings.label,
+          marginBottom: tokens.space.md,
+          fontWeight: 400,
+        }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * Overlays and screens paint themselves over the whole viewport, which would bury the rest
+ * of the gallery and swallow its clicks. `transform` makes this box the containing block
+ * for `position: fixed` descendants, so an overlay fills the stage instead of the window —
+ * the one reliable way to pin a fixed element without altering the component itself.
+ */
+function Stage({ height = 260, children }: { height?: number; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        position: "relative",
+        height,
+        overflow: "hidden",
+        transform: "translateZ(0)",
+        border: `1px dashed ${tokens.colors.border.default.dark}`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default function UiGalleryPage() {
+  // Read after mount, never during render. The app is a static export, so the prerendered
+  // HTML has no query string to consult — deriving the theme inline would disagree with the
+  // server markup and trip a hydration mismatch. Tests poll for the corrected value.
+  const [theme, setTheme] = useState<ThemeName>("dark");
+  useEffect(() => {
+    const requested = new URLSearchParams(window.location.search).get("theme");
+    setTheme(requested === "light" ? "light" : "dark");
+  }, []);
+
+  const [lastEvent, setLastEvent] = useState("");
+  const [query, setQuery] = useState("#in");
+  const [draft, setDraft] = useState(NOTE_BODY);
+
+  return (
+    <ThemeProvider theme={theme}>
+      <div
+        data-testid="gallery"
+        style={{
+          minHeight: "100vh",
+          background: tokens.colors.bg.app[theme],
+          color: tokens.colors.fg.default[theme],
+          fontFamily: tokens.fonts.mono,
+          fontSize: tokens.fontSizes.md,
+          padding: tokens.space.xl,
+        }}
+      >
+        <div style={{ marginBottom: tokens.space.xl }}>
+          notedude design system —{" "}
+          <span data-testid="last-event" style={{ opacity: tokens.opacities.dim }}>
+            {lastEvent}
+          </span>
+        </div>
+
+        <Section name="buttons" title="Button">
+          <div style={{ display: "flex", gap: tokens.space.lg, alignItems: "center", flexWrap: "wrap" }}>
+            <Button onClick={() => setLastEvent("button:default")}>⏎ sign in with google</Button>
+            <Button variant="outline" onClick={() => setLastEvent("button:outline")}>
+              <u>d</u>emo mode
+            </Button>
+            <Button variant="link" onClick={() => setLastEvent("button:link")}>logout</Button>
+            <div style={{ display: "flex", width: 240 }}>
+              <Button variant="toolbar" onClick={() => setLastEvent("button:toolbar")}>+ new note</Button>
+            </div>
+          </div>
+        </Section>
+
+        <Section name="rule" title="Rule">
+          <Rule />
+        </Section>
+
+        <Section name="divider" title="PaneDivider">
+          <div style={{ display: "flex", height: 80 }}>
+            <PaneDivider rows={8} />
+          </div>
+        </Section>
+
+        <Section name="searchbar" title="SearchBar">
+          <SearchBar value={query} onChange={setQuery} active onActivate={() => setLastEvent("search:activate")} />
+        </Section>
+
+        <Section name="tag-dropdown-search" title="TagDropdown — search">
+          <div style={{ position: "relative", height: 120 }}>
+            <TagDropdown
+              variant="search"
+              tags={TAGS}
+              selectedIndex={0}
+              recentCount={1}
+              onSelect={(tag) => setLastEvent(`tag:${tag}`)}
+            />
+          </div>
+        </Section>
+
+        <Section name="tag-dropdown-editor" title="TagDropdown — editor">
+          <div style={{ position: "relative", height: 120 }}>
+            <TagDropdown
+              variant="editor"
+              tags={TAGS}
+              selectedIndex={-1}
+              recentCount={2}
+              position={{ top: 0, left: 0 }}
+              onSelect={(tag) => setLastEvent(`editor-tag:${tag}`)}
+            />
+          </div>
+        </Section>
+
+        <Section name="note-list" title="NoteList">
+          <NoteList
+            notes={NOTES}
+            archivedNotes={ARCHIVED}
+            selectedId="n1"
+            flashingId={null}
+            onSelect={(id) => setLastEvent(`select:${id}`)}
+          />
+        </Section>
+
+        <Section name="note-content" title="NoteContent — read">
+          <Stage height={140}>
+            <NoteContent onClick={() => setLastEvent("content:click")}>
+              <NoteText content={NOTE_BODY} />
+            </NoteContent>
+          </Stage>
+        </Section>
+
+        <Section name="note-editor" title="NoteEditor">
+          <Stage height={140}>
+            <NoteContent>
+              <NoteEditor value={draft} onChange={(e) => setDraft(e.target.value)} />
+            </NoteContent>
+          </Stage>
+        </Section>
+
+        <Section name="help-overlay" title="HelpOverlay">
+          <Stage height={320}>
+            <HelpOverlay sections={SHORTCUTS} onDismiss={() => setLastEvent("help:dismiss")} />
+          </Stage>
+        </Section>
+
+        <Section name="task-move-dialog" title="TaskMoveDialog">
+          <Stage height={260}>
+            <TaskMoveDialog
+              tags={TASK_TAGS}
+              selectedIndex={1}
+              onSelect={(tag) => setLastEvent(`task:${tag}`)}
+              onDismiss={() => setLastEvent("task:dismiss")}
+            />
+          </Stage>
+        </Section>
+
+        <Section name="mobile-toolbar" title="MobileToolbar">
+          <MobileToolbar
+            view="list"
+            onCompose={() => setLastEvent("compose")}
+            onBack={() => setLastEvent("back")}
+          />
+        </Section>
+
+        <Section name="account-header" title="AccountHeader">
+          <AccountHeader>
+            leo@example.com
+            <Button variant="link" style={{ marginLeft: tokens.space.md }} onClick={() => setLastEvent("logout")}>
+              logout
+            </Button>
+          </AccountHeader>
+        </Section>
+
+        <Section name="footer" title="Footer">
+          <Footer />
+        </Section>
+
+        <Section name="login-screen" title="LoginScreen">
+          <Stage height={320}>
+            <LoginScreen
+              onSignIn={() => setLastEvent("signin")}
+              onDemo={() => setLastEvent("demo")}
+              error="Sign-in was cancelled."
+            />
+          </Stage>
+        </Section>
+
+        <Section name="loading-screen" title="LoadingScreen">
+          <Stage height={120}>
+            <LoadingScreen />
+          </Stage>
+        </Section>
+      </div>
+    </ThemeProvider>
+  );
+}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,6 +3,27 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { subscribeToNotes, saveNote, setNotePinned, setNoteTagPinned, setNoteContent, accountHasNotes, type NoteData } from "../lib/notes";
 import { takePendingShare } from "../lib/share";
+import {
+  colors,
+  contentWithoutTags,
+  fonts,
+  fontSizes,
+  Footer,
+  HelpOverlay,
+  MobileToolbar,
+  NoteContent,
+  NoteEditor,
+  NoteList,
+  NoteText,
+  PaneDivider,
+  Rule,
+  SearchBar,
+  TagDropdown,
+  TaskMoveDialog,
+  ThemeProvider,
+  zIndices,
+  type ShortcutSection,
+} from "@notedude/ui";
 
 interface Note {
   id: string;
@@ -25,12 +46,6 @@ const INITIAL_NOTES: Note[] = [
   { id: "6", content: "Archive #archive\nOld notes go here.", pinned: false, tagPinned: false, createdAt: 6, updatedAt: 6 },
   { id: "7", content: "Ideas #ideas\nCapture them here.", pinned: false, tagPinned: false, createdAt: 7, updatedAt: 7 },
 ];
-
-// What is left of a note once every #tag is stripped out. A note with nothing left holds
-// no text the user actually wrote — only tags it inherited from the active filter.
-function contentWithoutTags(content: string): string {
-  return content.replace(/#[\w-]+/g, "").trim();
-}
 
 // Below this width the list pane (250px) and content pane cannot sit side by side and
 // stay usable, so the two are shown one at a time instead (#108).
@@ -56,62 +71,6 @@ const NON_INHERITABLE_TAGS = new Set(["#archived"]);
 function inheritedTags(query: string): string[] {
   const tags = (query.match(/#[\w-]+/g) ?? []).map((t) => t.toLowerCase());
   return Array.from(new Set(tags)).filter((t) => !NON_INHERITABLE_TAGS.has(t));
-}
-
-// Index of the first line with something on it, or -1 if every line is blank. The title is
-// this line, not literally line 1: a note that opens with empty lines still has a title, it
-// just sits further down. Deriving it from line 1 made any such note report "No Text
-// Entered" while the Content Pane plainly showed its text (#126).
-function firstNonBlankIndex(lines: string[]): number {
-  return lines.findIndex((l) => l.trim() !== "");
-}
-
-function getNoteTitle(note: Note): string {
-  if (note.isNew && contentWithoutTags(note.content) === "") return "New Note";
-  const lines = note.content.split("\n");
-  const titleIdx = firstNonBlankIndex(lines);
-  // Reserved for notes that genuinely hold no text — whitespace-only included, which used
-  // to slip through as a non-empty string and render the entry with no title at all.
-  return titleIdx === -1 ? "No Text Entered" : lines[titleIdx];
-}
-
-function getNoteMetaSnippet(note: Note): string {
-  if (contentWithoutTags(note.content) === "") return "No Content";
-  const lines = note.content.split("\n");
-  const titleIdx = firstNonBlankIndex(lines);
-  if (titleIdx === -1) return "No Content";
-  // Search below the title line, wherever that turned out to be.
-  const snippet = lines.slice(titleIdx + 1).find((l) => l.trim() !== "") ?? "";
-  return snippet.length > 30 ? snippet.slice(0, 30) + "…" : snippet;
-}
-
-function formatTimestamp(ts: number): string {
-  const d = new Date(ts);
-  const now = new Date();
-  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const startOfWeek = new Date(startOfToday);
-  startOfWeek.setDate(startOfToday.getDate() - startOfToday.getDay());
-
-  if (d >= startOfToday) {
-    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-  }
-  if (d >= startOfWeek) {
-    return d.toLocaleDateString([], { weekday: "short" });
-  }
-  return d.toLocaleDateString([], { month: "short", day: "numeric" });
-}
-
-const URL_RE = /https?:\/\/[^\s<>"]+/g;
-function renderWithLinks(text: string): React.ReactNode[] {
-  const parts: React.ReactNode[] = [];
-  let last = 0;
-  for (const m of text.matchAll(URL_RE)) {
-    if (m.index! > last) parts.push(text.slice(last, m.index));
-    parts.push(<a key={m.index} href={m[0]} target="_blank" rel="noopener noreferrer" style={{ color: "inherit", textDecorationColor: "#888" }}>{m[0]}</a>);
-    last = m.index! + m[0].length;
-  }
-  if (last < text.length) parts.push(text.slice(last));
-  return parts;
 }
 
 function sortNotes(notes: Note[]): Note[] {
@@ -207,6 +166,51 @@ function getHashTokenBeforeCursor(text: string, cursorPos: number): string | nul
   const match = before.match(/#[\w-]*$/);
   return match ? match[0] : null;
 }
+
+// The help overlay's contents. Data rather than markup, so the shortcut list is editable
+// without touching layout — HelpOverlay renders whatever it is given.
+const SHORTCUT_SECTIONS: ShortcutSection[] = [
+  ["navigation", [
+    ["j / ↓",   "next note"],
+    ["k / ↑",   "previous note"],
+    ["1 – 9",   "jump to note by position"],
+    ["⌘[ / ⌘]", "navigate back / forward in history"],
+    ["c",       "create new note (inherits tags from the active search)"],
+    ["Shift+C", "create new note, clearing the active search"],
+    ["⏎ / e",   "edit selected note"],
+    ["Esc / ⌘⏎", "save and exit editing"],
+  ]],
+  ["search", [
+    ["/",       "open search"],
+    ["⏎",       "apply search filter"],
+    ["Esc",     "apply filter and exit search"],
+    ["Esc Esc", "clear filter"],
+  ]],
+  ["pinning", [
+    ["p",       "pin note to top (idle mode)"],
+    ["Shift+P", "tag-pin note (top of search results when first tag matches)"],
+    ["○",       "indicator: pinned"],
+    ["#",       "indicator: tag-pinned (first tag matches active search)"],
+  ]],
+  ["to do list", [
+    ["t → i",   "#tasks-inbox"],
+    ["t → t",   "#tasks-today"],
+    ["t → n",   "#tasks-nearterm"],
+    ["t → l",   "#tasks-longterm"],
+    ["t → d",   "#tasks-done"],
+    ["t → m",   "move note to a task list (incl. done)"],
+  ]],
+  ["etc", [
+    ["Shift+Y", "archive note (tags #archived, moves to end of list)"],
+    ["z",       "undo last note action (archive / pin / task move)"],
+    ["Shift+Z", "redo last undone note action"],
+    ["d → m",   "toggle dark mode"],
+    ["d → d",   "open donate page"],
+    ["r → r",   "report an issue"],
+    ["l → l",   "log out"],
+    ["⌘/ or ?", "show this (⌘/ works from any mode)"],
+  ]],
+];
 
 const DEMO_STORAGE_KEY = "notedude_demo_notes";
 const DEMO_WELCOME: Note = {
@@ -312,10 +316,6 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
     const recency = new Map(extractTags(activeNotes).filter(t => TASK_TAGS.includes(t.tag)).map(t => [t.tag, t.lastUsed]));
     return [...TASK_TAGS].sort((a, b) => (recency.get(b) ?? 0) - (recency.get(a) ?? 0));
   })();
-
-  function getPinBullets(note: Note): { circle: boolean; hash: boolean } {
-    return { circle: note.pinned, hash: note.tagPinned };
-  }
 
   // The note under the editor, if any. It is exempt from filtering below.
   const editingId = appState === "editing" ? selectedId : null;
@@ -1219,285 +1219,138 @@ export default function App({ uid, onLogout, demo }: { uid?: string; onLogout?: 
     setMobileView("list");
   };
 
+  const themeName = darkMode ? "dark" : "light";
+
   return (
-    <div ref={appRef} tabIndex={-1} data-testid="app" data-state={appState} data-theme={darkMode ? "dark" : "light"} style={{ display: "flex", flexDirection: "column", height: "100%", outline: "none", fontFamily: "'Fira Code', monospace", fontSize: 14, background: darkMode ? "#1a1a1a" : "#ffffff", color: darkMode ? "#e8e8e8" : "#000000" }}>
-      {/* Top Pane */}
-      <div data-testid="top-pane" style={{ padding: "8px 8px 8px 8px", display: "flex", alignItems: "center", flexShrink: 0 }}>
-        <span style={{ userSelect: "none", marginRight: 4 }}>&gt;</span>
-        <input
-          ref={searchRef}
-          type="search"
-          role="searchbox"
-          placeholder="search notes..."
+    <ThemeProvider theme={themeName}>
+      <div
+        ref={appRef}
+        tabIndex={-1}
+        data-testid="app"
+        data-state={appState}
+        data-theme={themeName}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          outline: "none",
+          fontFamily: fonts.mono,
+          fontSize: fontSizes.md,
+          background: colors.bg.app[themeName],
+          color: colors.fg.default[themeName],
+        }}
+      >
+        <SearchBar
           value={filterQuery}
-          onChange={(e) => { setFilterQuery(e.target.value); setSelectedTagIndex(-1); setTagDropdownDismissed(false); }}
-          readOnly={appState !== "search"}
-          onClick={() => { if (appState !== "search") { setAppState("search"); } }}
-          style={{ width: "100%", padding: "4px 0", fontFamily: "inherit", fontSize: "inherit", border: "none", outline: "none", background: "transparent", color: "inherit" }}
-        />
-      </div>
-      {/* Zero-height anchor. The dropdown hangs off it as an overlay rather than sitting in
-          the column, where opening it shoved the panes below down 48px and closing it
-          yanked them back (#124). Mirrors editor-tag-dropdown, which is already absolute. */}
-      <div style={{ position: "relative", zIndex: 20 }}>
-      {showTagDropdown && filteredTags.length > 0 && (
-        <div data-testid="tag-dropdown" style={{ position: "absolute", top: 0, left: 0, right: 0, padding: "4px 8px", background: darkMode ? "#2a2a2a" : "#f5f5f5", border: `1px solid ${darkMode ? "#444" : "#ddd"}` }}>
-          {filteredTags.map(({ tag }, i) => (
-            <div key={tag}>
-              {i === recentTagCount && recentTagCount > 0 && recentTagCount < filteredTags.length && (
-                <div data-testid="tag-separator" style={{ borderTop: `1px solid ${darkMode ? "#444" : "#ccc"}`, margin: "4px 0" }} />
-              )}
-              <div
-                data-testid="tag-item"
-                data-selected={i === selectedTagIndex ? "true" : "false"}
-                onClick={() => selectTag(tag)}
-                style={{ padding: "4px 8px", cursor: "pointer", background: i === selectedTagIndex ? (darkMode ? "#3a3a6a" : "#e0e7ff") : "transparent" }}
-              >
-                {tag}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-      </div>
-      <div style={{ overflow: "hidden", whiteSpace: "nowrap", color: darkMode ? "#555" : "#000", lineHeight: "1.4", userSelect: "none", flexShrink: 0, fontSize: 14 }}>
-        {"- ".repeat(300)}
-      </div>
-
-      {/* minHeight: 0 so this row shrinks to the space left over instead of being sized by
-          its own content — the divider column alone is hundreds of rows tall (#124). */}
-      <div style={{ display: "flex", flex: 1, minHeight: 0, overflow: "hidden" }}>
-        {/* List Pane */}
-        {showList && (
-        <div ref={listPaneRef} data-testid="list-pane" style={{ width: isNarrow ? "100%" : 250, overflowY: "auto" }}>
-          {[...displayed, ...displayedArchived].map((note, i) => {
-            const isArchivedDivider = i === displayed.length && displayedArchived.length > 0;
-            return (
-              <React.Fragment key={note.id}>
-                {isArchivedDivider && (
-                  <div data-testid="archived-divider" style={{ fontSize: 10, opacity: 0.4, textTransform: "uppercase", letterSpacing: "0.08em", padding: "6px 8px 2px", userSelect: "none" }}>
-                    archived
-                  </div>
-                )}
-                <div
-                  data-testid="note-item"
-                  data-selected={note.id === selectedId ? "true" : "false"}
-                  data-pinned={note.pinned ? "true" : "false"}
-                  data-tagpinned={note.tagPinned ? "true" : "false"}
-                  data-archived={isArchived(note) ? "true" : "false"}
-                  data-flash={note.id === saveFlashId ? "true" : "false"}
-                  onClick={() => { setSelectedId(note.id); setMobileView("content"); }}
-                  style={{
-                    padding: 8,
-                    cursor: "pointer",
-                    background: note.id === saveFlashId
-                      ? (darkMode ? "#1a7a1a" : "#6fcf7f")
-                      : note.id === selectedId ? (darkMode ? "#3a3a6a" : "#e0e7ff") : "transparent",
-                    transition: "background 0.3s ease",
-                    opacity: isArchived(note) ? 0.5 : 1,
-                  }}
-                >
-                  <div data-testid="note-item-title" style={{ fontWeight: 400, fontSize: 14, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                    {(() => { const b = getPinBullets(note); return (<>{b.circle && <span style={{ marginRight: 2 }}>○</span>}{b.hash && <span style={{ fontSize: "0.75em", opacity: 0.6, marginRight: 2 }}>#</span>}</>); })()}
-                    {getNoteTitle(note)}
-                  </div>
-                  <div data-testid="note-item-meta" style={{ fontSize: 12, color: darkMode ? "#999" : "#666", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                    {formatTimestamp(note.createdAt)} | {getNoteMetaSnippet(note)}
-                  </div>
-                </div>
-              </React.Fragment>
-            );
-          })}
-        </div>
-        )}
-
-        {/* The rule between panes only means anything when both are on screen. */}
-        {!isNarrow && (
-        <div data-testid="divider" style={{ overflow: "hidden", whiteSpace: "pre", color: darkMode ? "#555" : "#000", lineHeight: "1.4", userSelect: "none", width: "1ch", fontSize: 14 }}>
-          {("|\n").repeat(dividerRows)}
-        </div>
-        )}
-        {/* Content Pane */}
-        {showContent && (
-        <div
-          data-testid="content-pane"
-          onClick={(e) => {
-            // Click anywhere in the read-only pane to edit; don't hijack link clicks.
-            if (appState === "idle" && selectedId && !(e.target as HTMLElement).closest("a")) {
-              enterEditing(selectedId);
-            }
+          onChange={(value) => {
+            setFilterQuery(value);
+            setSelectedTagIndex(-1);
+            setTagDropdownDismissed(false);
           }}
-          style={{ flex: 1, padding: 16, overflowY: "auto", position: "relative" }}
-        >
-          {selectedNote && appState === "editing" && selectedNote.id === selectedId ? (
-            <>
-              <textarea
-                ref={editorRef}
-                role="textbox"
-                value={selectedNote.content}
-                onChange={handleContentChange}
-                onPaste={handlePaste}
-                onSelect={(e) => {
-                  const ta = e.target as HTMLTextAreaElement;
-                  const pos = ta.selectionStart ?? 0;
-                  setEditorCursorPos(pos);
-                  setEditorDropdownPos(getCursorPixelPos(ta, pos));
-                }}
-                // padding: 0 overrides the browser default of 2px on a textarea, which would
-                // otherwise nudge text down and right on edit and back again on save (#91)
-                style={{ width: "100%", height: "100%", padding: 0, border: "none", outline: "none", resize: "none", fontFamily: "inherit", fontSize: "inherit", lineHeight: "inherit", background: "transparent", color: "inherit" }}
-              />
-              {showEditorTagDropdown && editorFilteredTags.length > 0 && (
-                <div
-                  data-testid="editor-tag-dropdown"
-                  style={{ position: "absolute", top: editorDropdownPos.top, left: editorDropdownPos.left, background: darkMode ? "#2a2a2a" : "#f5f5f5", border: `1px solid ${darkMode ? "#444" : "#ddd"}`, zIndex: 10, minWidth: 120 }}
-                >
-                  {editorFilteredTags.map(({ tag }, i) => (
-                    <div key={tag}>
-                      {i === editorRecentTagCount && editorRecentTagCount < editorFilteredTags.length && (
-                        <div data-testid="editor-tag-separator" style={{ borderTop: `1px solid ${darkMode ? "#444" : "#ccc"}`, margin: "4px 0" }} />
-                      )}
-                      <div
-                        data-testid="editor-tag-item"
-                        data-selected={i === editorTagIndex ? "true" : "false"}
-                        onMouseDown={(e) => { e.preventDefault(); insertEditorTag(tag); }}
-                        style={{ padding: "4px 8px", cursor: "pointer", background: i === editorTagIndex ? (darkMode ? "#3a3a6a" : "#e0e7ff") : "transparent" }}
-                      >
-                        {tag}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </>
-          ) : (
-            <div style={{ whiteSpace: "pre-wrap", minHeight: "100%" }}>{renderWithLinks(selectedNote?.content ?? "")}</div>
+          active={appState === "search"}
+          onActivate={() => setAppState("search")}
+          inputRef={searchRef}
+        />
+
+        {/* Zero-height anchor. The dropdown hangs off it as an overlay rather than sitting in
+            the column, where opening it shoved the panes below down 48px and closing it
+            yanked them back (#124). */}
+        <div style={{ position: "relative", zIndex: zIndices.dropdown }}>
+          {showTagDropdown && (
+            <TagDropdown
+              variant="search"
+              tags={filteredTags}
+              selectedIndex={selectedTagIndex}
+              recentCount={recentTagCount}
+              onSelect={selectTag}
+            />
           )}
         </div>
+
+        <Rule />
+
+        {/* minHeight: 0 so this row shrinks to the space left over instead of being sized by
+            its own content — the divider column alone is hundreds of rows tall (#124). */}
+        <div style={{ display: "flex", flex: 1, minHeight: 0, overflow: "hidden" }}>
+          {showList && (
+            <NoteList
+              notes={displayed}
+              archivedNotes={displayedArchived}
+              selectedId={selectedId}
+              flashingId={saveFlashId}
+              onSelect={(id) => { setSelectedId(id); setMobileView("content"); }}
+              fullWidth={isNarrow}
+              listRef={listPaneRef}
+            />
+          )}
+
+          {/* The rule between panes only means anything when both are on screen. */}
+          {!isNarrow && <PaneDivider rows={dividerRows} />}
+
+          {showContent && (
+            <NoteContent
+              onClick={(e) => {
+                // Click anywhere in the read-only pane to edit; don't hijack link clicks.
+                if (appState === "idle" && selectedId && !(e.target as HTMLElement).closest("a")) {
+                  enterEditing(selectedId);
+                }
+              }}
+            >
+              {selectedNote && appState === "editing" && selectedNote.id === selectedId ? (
+                <>
+                  <NoteEditor
+                    value={selectedNote.content}
+                    onChange={handleContentChange}
+                    onPaste={handlePaste}
+                    onSelect={(e) => {
+                      const ta = e.target as HTMLTextAreaElement;
+                      const pos = ta.selectionStart ?? 0;
+                      setEditorCursorPos(pos);
+                      setEditorDropdownPos(getCursorPixelPos(ta, pos));
+                    }}
+                    editorRef={editorRef}
+                  />
+                  {showEditorTagDropdown && (
+                    <TagDropdown
+                      variant="editor"
+                      tags={editorFilteredTags}
+                      selectedIndex={editorTagIndex}
+                      recentCount={editorRecentTagCount}
+                      position={editorDropdownPos}
+                      onSelect={insertEditorTag}
+                    />
+                  )}
+                </>
+              ) : (
+                <NoteText content={selectedNote?.content ?? ""} />
+              )}
+            </NoteContent>
+          )}
+        </div>
+
+        {isNarrow && (
+          <MobileToolbar
+            view={mobileView}
+            onCompose={() => createNote(inheritedTags(activeFilter))}
+            onBack={leaveContentPane}
+          />
+        )}
+
+        <Footer />
+
+        {showHelp && (
+          <HelpOverlay sections={SHORTCUT_SECTIONS} onDismiss={() => setShowHelp(false)} />
+        )}
+
+        {showTaskMove && (
+          <TaskMoveDialog
+            tags={taskTagsSorted}
+            selectedIndex={taskMoveIndex}
+            onSelect={(tag) => { if (selectedId) applyTaskTag(selectedId, tag); }}
+            onDismiss={() => setShowTaskMove(false)}
+          />
         )}
       </div>
-      {/* Touch equivalents for the two shortcuts you cannot reach without a keyboard:
-          'c' to compose and Esc to leave the note. Narrow viewports only (#108). */}
-      {isNarrow && (
-        <div
-          data-testid="mobile-toolbar"
-          style={{ display: "flex", gap: 8, padding: 8, borderTop: `1px solid ${darkMode ? "#333" : "#ddd"}` }}
-        >
-          {mobileView === "list" ? (
-            <button
-              data-testid="mobile-compose"
-              onClick={() => createNote(inheritedTags(activeFilter))}
-              style={{ flex: 1, padding: "12px 16px", fontFamily: "inherit", fontSize: 14, cursor: "pointer", background: "transparent", border: `1px solid ${darkMode ? "#444" : "#ccc"}`, color: "inherit" }}
-            >
-              + new note
-            </button>
-          ) : (
-            <button
-              data-testid="mobile-back"
-              onClick={leaveContentPane}
-              style={{ flex: 1, padding: "12px 16px", fontFamily: "inherit", fontSize: 14, cursor: "pointer", background: "transparent", border: `1px solid ${darkMode ? "#444" : "#ccc"}`, color: "inherit" }}
-            >
-              &larr; notes
-            </button>
-          )}
-        </div>
-      )}
-      <div style={{ padding: "8px", textAlign: "center", fontSize: 12, color: "#888", userSelect: "none", flexShrink: 0 }}>
-        notedude &bull; an <a href="https://nbino.tech" target="_blank" rel="noopener noreferrer" style={{ color: "#888", textDecoration: "underline" }}>nbino</a> production
-      </div>
-      {showHelp && (
-        <div
-          data-testid="help-overlay"
-          onClick={() => setShowHelp(false)}
-          style={{ position: "fixed", inset: 0, background: darkMode ? "rgba(0,0,0,0.85)" : "rgba(255,255,255,0.95)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 100, fontFamily: "inherit" }}
-        >
-          <div style={{ maxWidth: 560, width: "100%", padding: "32px 40px", color: darkMode ? "#e8e8e8" : "#000", overflowY: "auto", maxHeight: "90vh" }}>
-            <div style={{ marginBottom: 24, fontSize: 16 }}>keyboard shortcuts</div>
-            {([
-              ["navigation", [
-                ["j / ↓",   "next note"],
-                ["k / ↑",   "previous note"],
-                ["1 – 9",   "jump to note by position"],
-                ["⌘[ / ⌘]", "navigate back / forward in history"],
-                ["c",       "create new note (inherits tags from the active search)"],
-                ["Shift+C", "create new note, clearing the active search"],
-                ["⏎ / e",   "edit selected note"],
-                ["Esc / ⌘⏎", "save and exit editing"],
-              ]],
-              ["search", [
-                ["/",       "open search"],
-                ["⏎",       "apply search filter"],
-                ["Esc",     "apply filter and exit search"],
-                ["Esc Esc", "clear filter"],
-              ]],
-              ["pinning", [
-                ["p",       "pin note to top (idle mode)"],
-                ["Shift+P", "tag-pin note (top of search results when first tag matches)"],
-                ["○",       "indicator: pinned"],
-                ["#",       "indicator: tag-pinned (first tag matches active search)"],
-              ]],
-              ["to do list", [
-                ["t → i",   "#tasks-inbox"],
-                ["t → t",   "#tasks-today"],
-                ["t → n",   "#tasks-nearterm"],
-                ["t → l",   "#tasks-longterm"],
-                ["t → d",   "#tasks-done"],
-                ["t → m",   "move note to a task list (incl. done)"],
-              ]],
-              ["etc", [
-                ["Shift+Y", "archive note (tags #archived, moves to end of list)"],
-                ["z",       "undo last note action (archive / pin / task move)"],
-                ["Shift+Z", "redo last undone note action"],
-                ["d → m",   "toggle dark mode"],
-                ["d → d",   "open donate page"],
-                ["r → r",   "report an issue"],
-                ["l → l",   "log out"],
-                ["⌘/ or ?", "show this (⌘/ works from any mode)"],
-              ]],
-            ] as [string, [string, string][]][]).map(([section, rows]) => (
-              <div key={section} style={{ marginBottom: 20 }}>
-                <div style={{ fontSize: 11, opacity: 0.4, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 8 }}>{section}</div>
-                <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14 }}>
-                  <tbody>
-                    {rows.map(([key, desc]) => (
-                      <tr key={key}>
-                        <td style={{ paddingBottom: 6, paddingRight: 32, whiteSpace: "nowrap", opacity: 0.5, width: 100 }}>{key}</td>
-                        <td style={{ paddingBottom: 6 }}>{desc}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            ))}
-            <div style={{ marginTop: 8, fontSize: 12, opacity: 0.4 }}>press any key or click to close</div>
-          </div>
-        </div>
-      )}
-      {showTaskMove && (
-        <div
-          data-testid="task-move-overlay"
-          onClick={() => setShowTaskMove(false)}
-          style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.5)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 200 }}
-        >
-          <div
-            onClick={e => e.stopPropagation()}
-            style={{ background: darkMode ? "#2a2a2a" : "#fff", border: `1px solid ${darkMode ? "#555" : "#ccc"}`, borderRadius: 6, padding: "16px 24px", minWidth: 220, fontFamily: "'Fira Code', monospace", fontSize: 14 }}
-          >
-            <div style={{ marginBottom: 12, fontSize: 12, opacity: 0.5 }}>move note to task list</div>
-            {taskTagsSorted.map((tag, i) => (
-              <div
-                key={tag}
-                data-testid="task-move-item"
-                data-selected={i === taskMoveIndex ? "true" : "false"}
-                onClick={() => { if (selectedId) applyTaskTag(selectedId, tag); }}
-                style={{ padding: "6px 8px", borderRadius: 4, cursor: "pointer", background: i === taskMoveIndex ? (darkMode ? "#444" : "#e8e8e8") : "transparent", color: darkMode ? "#e8e8e8" : "#000" }}
-              >
-                {tag}
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
+    </ThemeProvider>
   );
 }


### PR DESCRIPTION
Closes #141.

Extracts the presentational layer out of `App.tsx` (1503 lines) and `page.tsx` into a workspace package, so the UI has a reusable, themeable component surface instead of inline style objects duplicated across two files.

## Two commits, deliberately separable

1. **`a0d89e2` — add the library.** Nothing in `src/` imports it except the new gallery route, so the app is untouched and the suite is unaffected.
2. **`1f82313` — move the app onto it.** Pure substitution: every `data-testid`, every rendered style, and every behaviour unchanged.

## What changed

| | Before | After |
|---|---|---|
| `App.tsx` | 1503 lines | 1356 |
| Inline `style={{}}` in `App.tsx` | 38 | 3 |
| Hardcoded hex in `App.tsx` / `page.tsx` | ~20 literals, duplicated across both | **0** |

The three surviving style objects are the app root (the theme boundary), the dropdown anchor, and the pane row — each carries layout that is genuinely App's, not the library's.

`App.tsx` keeps everything stateful: the state machine, the global keyboard handler, Firestore sync, undo/redo, and all filtering and sorting. The library holds no application state and never reaches the network.

## The package

`packages/ui`, built to `dist/` by esbuild with declarations from `tsc`, React left external so the app and library share one instance. The app's `prebuild` / `predev` build it, so CI needs no new step.

**Tokens.** `tokens.ts` is the single place a colour, step, or size is decided. Colours are dark/light pairs that `ThemeProvider` resolves, so components read `c.bg.app` instead of re-deciding the theme at each use.

Three greys turned out to be genuinely distinct and are kept apart: `fg.muted` (note metadata, `#999`/`#666`), `fg.dim` (account header and secondary buttons, `#888`/`#666`), and `fg.subtle` (the footer — the *same* grey in both themes, so it recedes equally against black and white). Collapsing them would have been a visual regression.

**17 components**, in four groups: foundation (`ThemeProvider`/`useTheme`, `Button`), layout and chrome (`AppShell`, `AppSlot`, `AccountHeader`, `SearchBar`, `Rule`, `PaneDivider`, `MobileToolbar`, `Footer`), notes (`NoteList`, `NoteListItem`, `NoteContent`, `NoteText`, `NoteEditor`, `TagDropdown`), and screens/overlays (`HelpOverlay`, `TaskMoveDialog`, `LoginScreen`, `LoadingScreen`).

Worth a look:

- **`TagDropdown` collapses both dropdowns into one component.** The search dropdown and the editor's caret popover differ only in anchoring, test-id prefix, and how a row commits — the editor variant commits on `mousedown` with the default prevented, so the textarea never loses focus and the caret stays where the tag is going. That subtlety is now stated in one place instead of being implicit in two.
- **`useTheme` throws outside a provider** rather than defaulting to dark. A wrong-but-plausible theme is much harder to notice than a crash.

## Testing

`/test/ui` renders every component with representative props, and `e2e/ui-gallery.spec.ts` adds **40 contract tests** through it: rendering, the test ids the app suite depends on, per-theme colour resolution (including that the footer grey is intentionally theme-invariant), and the monospace character grid — the `|` divider is asserted to be exactly one character wide.

Run the way CI runs it, against the production export:

```
CI=true npx playwright test
  294 passed (55.7s)
```

That is the 254 pre-existing tests plus the 40 new ones, with no failures and nothing skipped.

## Behaviour deliberately preserved

`page.tsx` and `App.tsx` each read the stored theme on mount and hold their own copy, and only App's is toggled by `d → m` — so toggling repaints the app but not the surrounding chrome until reload. That is pre-existing behaviour; "fixing" it here would have been a behaviour change smuggled into a refactor. It is now written down in `spec.md` under Dark Mode.

## Follow-up

`/design-sync` can now convert `packages/ui/dist` into a claude.ai/design project, so design work maps 1:1 onto shippable code. The gallery doubles as the usage examples that export is generated from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)